### PR TITLE
Add KOIS PID and planning hygiene rules

### DIFF
--- a/.cursor/rules/kois-planning-hygiene.mdc
+++ b/.cursor/rules/kois-planning-hygiene.mdc
@@ -1,0 +1,17 @@
+---
+description: Keep KOIS planning artifacts aligned with implementation work
+alwaysApply: true
+---
+
+# KOIS Planning Hygiene
+
+This repository is evolving into the Kynd Opportunity Intelligence System (KOIS).
+
+When implementation work changes product scope, phase status, architecture, data model, integrations, or delivery surfaces:
+- update `PID.md` if the durable product understanding changes
+- update the KOIS Canvas at `/Users/holene/.cursor/projects/Users-holene-repos-kynd-job-scraper/canvases/kois-planning.canvas.tsx` if roadmap, phase status, deliverables, risks, or decisions change
+- keep both artifacts concise and aligned; do not duplicate detailed implementation notes
+- preserve KOIS boundaries: opportunity intelligence in KOIS, bid/CV intelligence in KBS
+- prefer evidence preservation, source provenance, and clustering over deleting or collapsing source records
+
+Before finishing substantial KOIS changes, explicitly check whether `PID.md` or the Canvas should be updated.

--- a/PID.md
+++ b/PID.md
@@ -1,0 +1,118 @@
+# Kynd Opportunity Intelligence System (KOIS) PID
+
+## Purpose
+
+KOIS is a provenance-first opportunity intelligence system for Kynd. It ingests assignment and procurement signals from email, broker portals, public tender platforms, scrapers, and APIs; preserves the raw evidence; groups related source items into opportunity clusters; and produces low-noise review queues, digests, and market intelligence.
+
+The first goal is not a smarter Slack bot. The first goal is a reliable assignment inbox, duplicate clustering, and data foundation.
+
+## Product Boundaries
+
+KOIS owns:
+- inbound opportunity and procurement signals
+- raw source evidence and extracted records
+- opportunity clustering and source comparison
+- DPS and frame-agreement market signals
+- review states, lightweight planning, and low-noise reporting
+- integration points for Slack, LLM APIs, Notion imports, and later KBS matching
+
+KOIS does not own:
+- CV storage
+- bid writing
+- project reference variants
+- candidate evaluation records
+- HR or recruitment systems
+- final CRM ownership unless explicitly added later
+
+## Guiding Principles
+
+- Preserve evidence; filter only in analysis and presentation.
+- Cluster duplicates; do not delete source records.
+- Prefer a primary source for display, not a single unquestioned canonical truth.
+- Keep field-level provenance where source values differ.
+- Use LLMs conservatively for extraction, classification, comparison, and drafting, not as the sole decision-maker.
+- Keep phase 1 lightweight: speed matters more than generic configurability.
+- Slack, Gemini, Notion, and broker portals are replaceable integrations, not architectural lock-ins.
+- Database is source of truth. Notion is a notebook or imported reference source.
+
+## Initial Priorities
+
+1. Assignment inbox, dedupe/clustering, and data foundation.
+2. Market analytics.
+3. Sales opportunity filtering.
+4. CV market-fit evaluation through KBS integration.
+
+## Conceptual Data Model
+
+- `RawSourceItem`: immutable inbound evidence such as email, scrape result, API payload, tender notice, or DPS update.
+- `ExtractedRecord`: structured data parsed from one source item.
+- `OpportunityCluster`: a grouped opportunity made from one or more extracted records.
+- `PrimarySource`: the preferred source for display and decisioning at a point in time.
+- `SourceComparison`: differences, overlaps, and additions across source records in a cluster.
+- `AgreementSignal`: DPS or frame-agreement information that may not be assignment-related.
+- `ReviewState`: `auto_accepted`, `needs_review`, `manually_merged`, `manually_split`, `ignored`, or `watch_only`.
+- `DigestItem`: generated output for Slack or reports, backed by stored evidence.
+- `ExternalFitAssessment`: later KBS-provided fit assessment for consultants, CVs, references, or bid material.
+
+## Source Priority
+
+KOIS should store all sources and compare them. For display and decisioning, sources closer to the buyer or procurement event normally outrank broker summaries.
+
+Initial primary-source preference:
+1. Public buyer or tender source such as Doffin or procurement-platform notice.
+2. Direct Kynd-owned agreement or buyer communication.
+3. Broker portal or broker email.
+4. Forwarded or manually entered source.
+
+This is a default policy, not a reason to discard broker details. Broker descriptions may add useful role framing, skills, pricing signals, or market evidence.
+
+## Phases
+
+### Phase 1: Foundation And Inbox
+
+Ingest `oppdrag@kynd.no` emails and current scraper outputs, preserve raw evidence, extract structured records, cluster likely duplicates, expose a basic review queue, and produce a conservative digest.
+
+Success metric: KOIS becomes a searchable assignment archive with fewer duplicate distractions than email.
+
+### Phase 2: Market And Agreement Intelligence
+
+Add Doffin and procurement monitoring, agreement-signal handling, buyer and broker analytics, and discovery of DPS or frame agreements Kynd may not have found or applied for.
+
+Success metric: KOIS identifies market patterns and agreement coverage gaps, not only new assignments.
+
+### Phase 3: Sales Opportunity Filtering
+
+Add lightweight role classification, availability-aware digest modes, source/relevance thresholds, and configurable Slack cadence.
+
+Success metric: Slack highlights fewer but better items while the archive remains complete.
+
+### Phase 4: KBS Integration
+
+Expose opportunity profiles to KBS and receive high-level fit assessments back. KOIS should not own CV or bid material.
+
+Success metric: KOIS can indicate which opportunities deserve deeper bid-system evaluation.
+
+### Phase 5: Recruitment Market Fit
+
+Use KOIS market history and KBS CV data to evaluate whether candidate profiles match recent demand and identify bid-framing gaps.
+
+Success metric: recruitment and CV positioning decisions are informed by observed market demand.
+
+## Delivery Surfaces
+
+- Basic UI for review, merge, split, ignore, and source comparison.
+- Slack channels for conservative digests, review prompts, and optionally DPS/agreement updates.
+- Periodic market reports.
+- Searchable archive.
+- API or export surface for KBS.
+
+## Canvas Maintenance
+
+The KOIS planning Canvas is the living planning surface. Keep it aligned with this PID whenever work changes:
+- update phase status when implementation starts or completes phase work
+- add or refine deliverables as plans become concrete
+- reflect decisions that change scope, boundaries, data model, or integration strategy
+- keep completed implementation details concise; link to code or plans instead of duplicating them
+
+Canvas path:
+`/Users/holene/.cursor/projects/Users-holene-repos-kynd-job-scraper/canvases/kois-planning.canvas.tsx`

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+## Job Scraper
+
+Async Python batch job that scrapes freelance assignments from Mercell, Verama, Folq, Emagine, and Witted, then posts only new listings to Slack.
+
+Flow per run:
+- scrape all sources in parallel with Playwright
+- diff against local state in `jobs.json`
+- summarize new descriptions with Gemini
+- post to Slack channel `job-posting`
+- persist newly seen jobs to `jobs.json`
+
+Required environment variables:
+- `GEMINI_API_KEY`
+- `SLACK_TOKEN`
+- `{PLATFORM}_USERNAME` and `{PLATFORM}_PASSWORD` for scraper platforms (current code path expects these for all configured scrapers)
+
+Setup and run:
+```bash
+uv sync
+uv run playwright install chromium
+cd job_scraper
+uv run python main.py
+```


### PR DESCRIPTION
## Summary
- Add `PID.md` defining the Kynd Opportunity Intelligence System (KOIS) product intent, boundaries, principles, and phased roadmap.
- Add `.cursor/rules/kois-planning-hygiene.mdc` so PID and Canvas updates stay aligned when scope or architecture changes.
- Update `README.md` with project setup and run instructions.

This PR re-introduces changes that were committed directly to `main`; `main` was reverted so review can happen through the normal PR flow.

## Test plan
- [ ] Review `PID.md` for accurate product boundaries and phase priorities
- [ ] Confirm Cursor planning hygiene rule references the correct Canvas path
- [ ] Merge via PR to satisfy branch protection


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and editor rules only; no runtime, auth, or data-path changes.
> 
> **Overview**
> **Adds KOIS product planning docs** and a Cursor workflow rule so implementation stays aligned with `PID.md` and the planning Canvas.
> 
> Introduces **`PID.md`**, framing the repo’s direction toward the Kynd Opportunity Intelligence System: provenance-first ingestion, clustering (not deletion), KOIS vs KBS boundaries, conceptual entities (`RawSourceItem`, `OpportunityCluster`, etc.), source-priority policy, and a five-phase roadmap from inbox foundation through KBS integration.
> 
> Adds **`.cursor/rules/kois-planning-hygiene.mdc`** (`alwaysApply: true`) requiring updates to `PID.md` and the KOIS Canvas when scope, phases, architecture, or integrations change.
> 
> Adds **`README.md`** documenting the **current** async Playwright job scraper (platforms, `jobs.json` diffing, Gemini summaries, Slack posting, env vars, `uv` setup)—operational context alongside the KOIS vision, not new scraper behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a20f82487de0f8033c4af83d21dc88cc3bbdef79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->