### PR TITLE
Implement KOIS Phase 1 foundation pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 jobs.json
 
 __pycache__/
+.pytest_cache/
+.ruff_cache/

--- a/PID.md
+++ b/PID.md
@@ -74,6 +74,8 @@ Ingest `oppdrag@kynd.no` emails and current scraper outputs, preserve raw eviden
 
 Success metric: KOIS becomes a searchable assignment archive with fewer duplicate distractions than email.
 
+Implementation status: in progress. Current implementation uses Postgres-backed persistence, scraper + IMAP ingestion adapters, cluster/source comparison records, a minimal review API surface, and digest-item persistence.
+
 ### Phase 2: Market And Agreement Intelligence
 
 Add Doffin and procurement monitoring, agreement-signal handling, buyer and broker analytics, and discovery of DPS or frame agreements Kynd may not have found or applied for.

--- a/README.md
+++ b/README.md
@@ -1,25 +1,84 @@
-## Job Scraper
+## KOIS Phase 1 Foundation
 
-Async Python batch job that scrapes freelance assignments from Mercell, Verama, Folq, Emagine, and Witted, then posts only new listings to Slack.
+This repository now implements the KOIS Phase 1 foundation: provenance-first ingestion and clustering of assignment opportunities from broker scrapers and `oppdrag@kynd.no` (IMAP), with conservative Slack digest output backed by stored evidence.
 
-Python requirement: 3.12+
+Per run pipeline:
 
-Flow per run:
-- scrape all sources in parallel with Playwright
-- diff against local state in `jobs.json`
-- summarize new descriptions with Gemini
-- post to Slack channel `job-posting`
-- persist newly seen jobs to `jobs.json`
+1. scrape broker portals in parallel (`Mercell`, `Verama`, `Folq`, `Emagine`, `Witted`)
+2. ingest IMAP mailbox items from `oppdrag@kynd.no`
+3. persist immutable raw source evidence (`raw_source_items`)
+4. extract structured records (`extracted_records`)
+5. cluster likely duplicates with source comparisons (`opportunity_clusters`, `source_comparisons`)
+6. create review states (`review_states`) and conservative digest items (`digest_items`)
 
-Required environment variables:
-- `GEMINI_API_KEY`
-- `SLACK_TOKEN`
-- `{PLATFORM}_USERNAME` and `{PLATFORM}_PASSWORD` for scraper platforms (current code path expects these for all configured scrapers)
+### Requirements
 
-Setup and run:
+- Python 3.12+
+- PostgreSQL reachable via `DATABASE_URL`
+- Playwright Chromium for scraping
+
+### Environment Variables
+
+Core:
+
+- `DATABASE_URL` (example: `postgresql+psycopg://postgres:postgres@localhost:5432/kois`)
+- `RUN_LIVE_SLACK` (`false` by default; set `true` to post live)
+- `SLACK_CHANNEL` (`job-posting` default)
+
+Integrations:
+
+- `GEMINI_API_KEY` (optional; summarization/extraction enhancement)
+- `SLACK_TOKEN` (required only when `RUN_LIVE_SLACK=true`)
+- `{PLATFORM}_USERNAME` / `{PLATFORM}_PASSWORD` for each scraper
+
+IMAP (`oppdrag@kynd.no`):
+
+- `IMAP_HOST`
+- `IMAP_PORT` (default `993`)
+- `IMAP_USERNAME`
+- `IMAP_PASSWORD`
+- `IMAP_MAILBOX` (default `INBOX`)
+- `IMAP_SINCE_UID` (default `1`)
+- `IMAP_SOURCE_NAME` (default `oppdrag@kynd.no`)
+
+### Setup
+
 ```bash
-uv sync
-uv run playwright install chromium
-cd job_scraper
-uv run python main.py
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+python -m playwright install chromium
 ```
+
+### Run KOIS Pipeline
+
+```bash
+python -m job_scraper.main
+```
+
+### Review API (basic queue/archive surface)
+
+```bash
+uvicorn job_scraper.kois.review_api:app --reload
+```
+
+Useful endpoints:
+
+- `GET /health`
+- `GET /clusters`
+- `GET /clusters?q=<search>`
+- `GET /review-queue`
+- `PATCH /clusters/{cluster_id}/status` with `auto_accepted`, `needs_review`, `manually_merged`, `manually_split`, `ignored`, `watch_only`
+
+### Checks
+
+```bash
+ruff check .
+pytest
+```
+
+### Notes
+
+- Raw evidence is preserved even when extraction fails.
+- Deduplication is cluster-based; source records are retained.
+- Slack digest output is driven by persisted cluster state, not transient scraper output.

--- a/job_scraper/kois/__init__.py
+++ b/job_scraper/kois/__init__.py
@@ -1,0 +1,1 @@
+"""KOIS Phase 1 package."""

--- a/job_scraper/kois/clustering.py
+++ b/job_scraper/kois/clustering.py
@@ -81,6 +81,13 @@ def _similarity(record: ExtractedRecord, cluster: OpportunityCluster) -> tuple[f
     return min(score, 1.0), ",".join(parts) or "weak-match"
 
 
+def refresh_clusters(session: Session, clusters: list[OpportunityCluster]) -> None:
+    if not clusters:
+        return
+    _refresh_comparisons(session, clusters)
+    _refresh_primary_sources(session, clusters)
+
+
 def cluster_records(session: Session, records: list[ExtractedRecord]) -> list[OpportunityCluster]:
     clusters: list[OpportunityCluster] = []
     for record in records:

--- a/job_scraper/kois/clustering.py
+++ b/job_scraper/kois/clustering.py
@@ -6,7 +6,7 @@ from job_scraper.kois.extraction import make_cluster_key
 from job_scraper.kois.repository import (
     attach_cluster_source,
     create_or_update_cluster,
-    create_source_comparison,
+    upsert_source_comparison,
 )
 from job_scraper.kois.schema import ExtractedRecord, OpportunityCluster, ReviewStatus
 from job_scraper.kois.utils import normalize_text, normalize_url
@@ -95,7 +95,7 @@ def _refresh_comparisons(session: Session, clusters: list[OpportunityCluster]) -
 
         for field_name, values in field_values.items():
             if len(values) > 1:
-                create_source_comparison(
+                upsert_source_comparison(
                     session=session,
                     cluster=cluster,
                     field_name=field_name,

--- a/job_scraper/kois/clustering.py
+++ b/job_scraper/kois/clustering.py
@@ -11,6 +11,7 @@ from job_scraper.kois.repository import (
     upsert_source_comparison,
 )
 from job_scraper.kois.schema import (
+    ClusterSource,
     ExtractedRecord,
     OpportunityCluster,
     ReviewStatus,
@@ -63,7 +64,21 @@ def _source_rank(record: ExtractedRecord) -> int:
     return SOURCE_PRIORITY[_source_priority_key(record)]
 
 
-def _similarity(record: ExtractedRecord, cluster: OpportunityCluster) -> tuple[float, str]:
+def _cluster_deadlines(session: Session, cluster_id: int) -> set[str]:
+    rows = session.execute(
+        select(ExtractedRecord.deadline)
+        .join(ClusterSource, ClusterSource.extracted_record_id == ExtractedRecord.id)
+        .where(
+            ClusterSource.opportunity_cluster_id == cluster_id,
+            ExtractedRecord.deadline.is_not(None),
+        )
+    ).scalars()
+    return {normalize_text(deadline) for deadline in rows if normalize_text(deadline)}
+
+
+def _similarity(
+    session: Session, record: ExtractedRecord, cluster: OpportunityCluster
+) -> tuple[float, str]:
     score = 0.0
     parts = []
     if normalize_url(record.source_url) and cluster.cluster_key == normalize_url(record.source_url):
@@ -75,7 +90,8 @@ def _similarity(record: ExtractedRecord, cluster: OpportunityCluster) -> tuple[f
     if normalize_text(record.customer) == normalize_text(cluster.customer):
         score += 0.1
         parts.append("customer")
-    if normalize_text(record.deadline):
+    record_deadline = normalize_text(record.deadline)
+    if record_deadline and record_deadline in _cluster_deadlines(session, cluster.id):
         score += 0.1
         parts.append("deadline")
     return min(score, 1.0), ",".join(parts) or "weak-match"
@@ -112,7 +128,7 @@ def cluster_records(session: Session, records: list[ExtractedRecord]) -> list[Op
             review_status=review_status,
         )
         clusters.extend(detach_superseded_cluster_sources(session, record))
-        match_confidence, rationale = _similarity(record, cluster)
+        match_confidence, rationale = _similarity(session, record, cluster)
         attach_cluster_source(session, cluster, record, match_confidence, rationale)
         clusters.append(cluster)
 

--- a/job_scraper/kois/clustering.py
+++ b/job_scraper/kois/clustering.py
@@ -1,0 +1,114 @@
+from collections import defaultdict
+
+from sqlalchemy.orm import Session
+
+from job_scraper.kois.extraction import make_cluster_key
+from job_scraper.kois.repository import (
+    attach_cluster_source,
+    create_or_update_cluster,
+    create_source_comparison,
+)
+from job_scraper.kois.schema import ExtractedRecord, OpportunityCluster, ReviewStatus
+from job_scraper.kois.utils import normalize_text, normalize_url
+
+
+SOURCE_PRIORITY = {
+    "doffin": 100,
+    "procurement": 90,
+    "direct": 80,
+    "broker": 70,
+    "email": 60,
+    "forwarded": 50,
+    "manual": 40,
+    "unknown": 10,
+}
+
+
+def _source_rank(record: ExtractedRecord) -> int:
+    broker = normalize_text(record.broker)
+    for key, value in SOURCE_PRIORITY.items():
+        if key in broker:
+            return value
+    return SOURCE_PRIORITY["unknown"]
+
+
+def _similarity(record: ExtractedRecord, cluster: OpportunityCluster) -> tuple[float, str]:
+    score = 0.0
+    parts = []
+    if normalize_url(record.source_url) and cluster.cluster_key == normalize_url(record.source_url):
+        score += 0.6
+        parts.append("url")
+    if normalize_text(record.title) == normalize_text(cluster.title):
+        score += 0.2
+        parts.append("title")
+    if normalize_text(record.customer) == normalize_text(cluster.customer):
+        score += 0.1
+        parts.append("customer")
+    if normalize_text(record.deadline):
+        score += 0.1
+        parts.append("deadline")
+    return min(score, 1.0), ",".join(parts) or "weak-match"
+
+
+def cluster_records(session: Session, records: list[ExtractedRecord]) -> list[OpportunityCluster]:
+    clusters: list[OpportunityCluster] = []
+    for record in records:
+        key = make_cluster_key(
+            {
+                "title": record.title,
+                "customer": record.customer,
+                "deadline": record.deadline,
+                "source_url": record.source_url,
+            }
+        )
+        confidence = 0.95 if normalize_url(record.source_url) else 0.7
+        review_status = (
+            ReviewStatus.AUTO_ACCEPTED if confidence >= 0.9 else ReviewStatus.NEEDS_REVIEW
+        )
+        cluster = create_or_update_cluster(
+            session=session,
+            cluster_key=key,
+            title=record.title,
+            customer=record.customer,
+            confidence=confidence,
+            review_status=review_status,
+        )
+        match_confidence, rationale = _similarity(record, cluster)
+        attach_cluster_source(session, cluster, record, match_confidence, rationale)
+        clusters.append(cluster)
+
+    _refresh_comparisons(session, clusters)
+    _refresh_primary_sources(session, clusters)
+    return clusters
+
+
+def _refresh_comparisons(session: Session, clusters: list[OpportunityCluster]) -> None:
+    unique_clusters = {cluster.id: cluster for cluster in clusters}.values()
+    for cluster in unique_clusters:
+        records = [source.record for source in cluster.sources]
+        field_values: dict[str, set[str]] = defaultdict(set)
+        for record in records:
+            for field_name in ("title", "customer", "broker", "deadline", "source_url"):
+                value = getattr(record, field_name, None)
+                if value:
+                    field_values[field_name].add(value)
+
+        for field_name, values in field_values.items():
+            if len(values) > 1:
+                create_source_comparison(
+                    session=session,
+                    cluster=cluster,
+                    field_name=field_name,
+                    values={"values": sorted(values)},
+                )
+
+
+def _refresh_primary_sources(session: Session, clusters: list[OpportunityCluster]) -> None:
+    unique_clusters = {cluster.id: cluster for cluster in clusters}.values()
+    for cluster in unique_clusters:
+        sources = [source.record for source in cluster.sources]
+        if not sources:
+            continue
+        primary = sorted(sources, key=_source_rank, reverse=True)[0]
+        cluster.primary_source_record_id = primary.id
+        session.flush()

--- a/job_scraper/kois/clustering.py
+++ b/job_scraper/kois/clustering.py
@@ -1,14 +1,21 @@
 from collections import defaultdict
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from job_scraper.kois.extraction import make_cluster_key
 from job_scraper.kois.repository import (
     attach_cluster_source,
     create_or_update_cluster,
+    detach_superseded_cluster_sources,
     upsert_source_comparison,
 )
-from job_scraper.kois.schema import ExtractedRecord, OpportunityCluster, ReviewStatus
+from job_scraper.kois.schema import (
+    ExtractedRecord,
+    OpportunityCluster,
+    ReviewStatus,
+    SourceComparison,
+)
 from job_scraper.kois.utils import normalize_text, normalize_url
 
 
@@ -97,6 +104,7 @@ def cluster_records(session: Session, records: list[ExtractedRecord]) -> list[Op
             confidence=confidence,
             review_status=review_status,
         )
+        clusters.extend(detach_superseded_cluster_sources(session, record))
         match_confidence, rationale = _similarity(record, cluster)
         attach_cluster_source(session, cluster, record, match_confidence, rationale)
         clusters.append(cluster)
@@ -117,14 +125,28 @@ def _refresh_comparisons(session: Session, clusters: list[OpportunityCluster]) -
                 if value:
                     field_values[field_name].add(value)
 
-        for field_name, values in field_values.items():
-            if len(values) > 1:
-                upsert_source_comparison(
-                    session=session,
-                    cluster=cluster,
-                    field_name=field_name,
-                    values={"values": sorted(values)},
+        divergent_values = {
+            field_name: values for field_name, values in field_values.items() if len(values) > 1
+        }
+        existing_comparisons = list(
+            session.execute(
+                select(SourceComparison).where(
+                    SourceComparison.opportunity_cluster_id == cluster.id
                 )
+            ).scalars()
+        )
+        for comparison in existing_comparisons:
+            if comparison.field_name not in divergent_values:
+                session.delete(comparison)
+
+        for field_name, values in divergent_values.items():
+            upsert_source_comparison(
+                session=session,
+                cluster=cluster,
+                field_name=field_name,
+                values={"values": sorted(values)},
+            )
+        session.flush()
 
 
 def _refresh_primary_sources(session: Session, clusters: list[OpportunityCluster]) -> None:
@@ -132,6 +154,8 @@ def _refresh_primary_sources(session: Session, clusters: list[OpportunityCluster
     for cluster in unique_clusters:
         sources = [source.record for source in cluster.sources]
         if not sources:
+            cluster.primary_source_record_id = None
+            session.flush()
             continue
         primary = sorted(
             sources,

--- a/job_scraper/kois/clustering.py
+++ b/job_scraper/kois/clustering.py
@@ -24,12 +24,36 @@ SOURCE_PRIORITY = {
 }
 
 
-def _source_rank(record: ExtractedRecord) -> int:
+def _source_priority_key(record: ExtractedRecord) -> str:
+    extracted_data = record.extracted_data or {}
+    source_type = normalize_text(extracted_data.get("source_type"))
+    platform = normalize_text(extracted_data.get("platform"))
+    host = normalize_text(extracted_data.get("host"))
     broker = normalize_text(record.broker)
-    for key, value in SOURCE_PRIORITY.items():
-        if key in broker:
-            return value
-    return SOURCE_PRIORITY["unknown"]
+    source_url = normalize_text(record.source_url)
+    fingerprint = " ".join(
+        part for part in (source_type, platform, host, broker, source_url) if part
+    )
+
+    if "doffin" in fingerprint:
+        return "doffin"
+    if "procurement" in fingerprint:
+        return "procurement"
+    if source_type == "email" or "@" in broker:
+        return "email"
+    if "forwarded" in fingerprint or "forward" in fingerprint:
+        return "forwarded"
+    if "manual" in fingerprint:
+        return "manual"
+    if source_type == "scraper" or "broker" in fingerprint:
+        return "broker"
+    if "direct" in fingerprint:
+        return "direct"
+    return "unknown"
+
+
+def _source_rank(record: ExtractedRecord) -> int:
+    return SOURCE_PRIORITY[_source_priority_key(record)]
 
 
 def _similarity(record: ExtractedRecord, cluster: OpportunityCluster) -> tuple[float, str]:
@@ -109,6 +133,14 @@ def _refresh_primary_sources(session: Session, clusters: list[OpportunityCluster
         sources = [source.record for source in cluster.sources]
         if not sources:
             continue
-        primary = sorted(sources, key=_source_rank, reverse=True)[0]
+        primary = sorted(
+            sources,
+            key=lambda record: (
+                _source_rank(record),
+                record.extraction_confidence or 0.0,
+                record.id,
+            ),
+            reverse=True,
+        )[0]
         cluster.primary_source_record_id = primary.id
         session.flush()

--- a/job_scraper/kois/config.py
+++ b/job_scraper/kois/config.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from functools import lru_cache
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class KOISSettings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+
+    database_url: str = Field(
+        default="postgresql+psycopg://postgres:postgres@localhost:5432/kois"
+    )
+
+    slack_token: str | None = Field(default=None, alias="SLACK_TOKEN")
+    slack_channel: str = "job-posting"
+
+    gemini_api_key: str | None = Field(default=None, alias="GEMINI_API_KEY")
+
+    imap_host: str | None = None
+    imap_port: int = 993
+    imap_username: str | None = None
+    imap_password: str | None = None
+    imap_mailbox: str = "INBOX"
+    imap_since_uid: int = 1
+    imap_source_name: str = "oppdrag@kynd.no"
+
+    run_live_slack: bool = False
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> KOISSettings:
+    return KOISSettings()

--- a/job_scraper/kois/db.py
+++ b/job_scraper/kois/db.py
@@ -1,0 +1,30 @@
+from collections.abc import Iterator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, declarative_base, sessionmaker
+
+from job_scraper.kois.config import get_settings
+
+Base = declarative_base()
+
+
+def create_db_engine():
+    settings = get_settings()
+    return create_engine(settings.database_url, future=True)
+
+
+SessionLocal = sessionmaker(
+    autocommit=False,
+    autoflush=False,
+    bind=create_db_engine(),
+    future=True,
+    expire_on_commit=False,
+)
+
+
+def get_db_session() -> Iterator[Session]:
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()

--- a/job_scraper/kois/digest.py
+++ b/job_scraper/kois/digest.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy.orm import Session
+
+from job_scraper.kois.repository import create_digest_item, mark_digest_sent
+from job_scraper.kois.schema import OpportunityCluster, ReviewStatus
+from job_scraper.slack_poster import SlackPoster
+
+
+@dataclass
+class DigestPayload:
+    title: str
+    customer: str | None
+    deadline: str | None
+    source_count: int
+    primary_source_record_id: int | None
+    confidence: float
+    review_status: str
+    cluster_id: int
+
+
+def cluster_to_payload(cluster: OpportunityCluster) -> DigestPayload:
+    return DigestPayload(
+        title=cluster.title or "Untitled opportunity",
+        customer=cluster.customer,
+        deadline=cluster.sources[0].record.deadline if cluster.sources else None,
+        source_count=len(cluster.sources),
+        primary_source_record_id=cluster.primary_source_record_id,
+        confidence=cluster.confidence,
+        review_status=cluster.review_status.value,
+        cluster_id=cluster.id,
+    )
+
+
+def select_digest_candidates(clusters: list[OpportunityCluster]) -> list[OpportunityCluster]:
+    candidates: list[OpportunityCluster] = []
+    for cluster in clusters:
+        if cluster.review_status in (ReviewStatus.IGNORED, ReviewStatus.WATCH_ONLY):
+            continue
+        if cluster.review_status == ReviewStatus.NEEDS_REVIEW and cluster.confidence < 0.75:
+            continue
+        candidates.append(cluster)
+    return candidates
+
+
+def send_digest_items(
+    session: Session,
+    clusters: list[OpportunityCluster],
+    slack: SlackPoster,
+    live_posting: bool,
+    channel: str,
+) -> list[dict]:
+    sent_payloads: list[dict] = []
+    for cluster in select_digest_candidates(clusters):
+        payload = cluster_to_payload(cluster)
+        digest_item = create_digest_item(
+            session=session,
+            cluster=cluster,
+            status=cluster.review_status,
+            payload=payload.__dict__,
+        )
+        if digest_item.sent_at is not None:
+            continue
+
+        slack_ts = None
+        if live_posting:
+            response = slack.post_digest(payload.__dict__, channel=channel)
+            slack_ts = None if response is None else response.get("ts")
+
+        mark_digest_sent(session, digest_item, slack_ts)
+        sent_payloads.append(payload.__dict__)
+    return sent_payloads

--- a/job_scraper/kois/digest.py
+++ b/job_scraper/kois/digest.py
@@ -64,10 +64,13 @@ def send_digest_items(
         if digest_item.sent_at is not None:
             continue
 
-        slack_ts = None
         if live_posting:
             response = slack.post_digest(payload.__dict__, channel=channel)
-            slack_ts = None if response is None else response.get("ts")
+            if response is None:
+                continue
+            slack_ts = response.get("ts")
+        else:
+            slack_ts = None
 
         mark_digest_sent(session, digest_item, slack_ts)
         sent_payloads.append(payload.__dict__)

--- a/job_scraper/kois/digest.py
+++ b/job_scraper/kois/digest.py
@@ -70,6 +70,9 @@ def send_digest_items(
 ) -> list[dict]:
     sent_payloads: list[dict] = []
     for cluster in clusters:
+        if not cluster.sources:
+            delete_unsent_digest_items(session, cluster)
+            continue
         if cluster.review_status in (ReviewStatus.IGNORED, ReviewStatus.WATCH_ONLY):
             delete_unsent_digest_items(session, cluster)
             continue

--- a/job_scraper/kois/digest.py
+++ b/job_scraper/kois/digest.py
@@ -25,23 +25,26 @@ class DigestPayload:
     cluster_id: int
 
 
-def _resolve_cluster_deadline(cluster: OpportunityCluster) -> str | None:
+def _resolve_primary_record(cluster: OpportunityCluster):
     if not cluster.sources:
         return None
 
     if cluster.primary_source_record_id is not None:
         for source in cluster.sources:
             if source.extracted_record_id == cluster.primary_source_record_id:
-                return source.record.deadline
+                return source.record
 
-    return cluster.sources[0].record.deadline
+    return cluster.sources[0].record
 
 
 def cluster_to_payload(cluster: OpportunityCluster) -> DigestPayload:
+    primary_record = _resolve_primary_record(cluster)
     return DigestPayload(
-        title=cluster.title or "Untitled opportunity",
-        customer=cluster.customer,
-        deadline=_resolve_cluster_deadline(cluster),
+        title=(primary_record.title if primary_record else None)
+        or cluster.title
+        or "Untitled opportunity",
+        customer=(primary_record.customer if primary_record else None) or cluster.customer,
+        deadline=primary_record.deadline if primary_record else None,
         source_count=len(cluster.sources),
         primary_source_record_id=cluster.primary_source_record_id,
         confidence=cluster.confidence,

--- a/job_scraper/kois/digest.py
+++ b/job_scraper/kois/digest.py
@@ -4,7 +4,11 @@ from dataclasses import dataclass
 
 from sqlalchemy.orm import Session
 
-from job_scraper.kois.repository import create_digest_item, mark_digest_sent
+from job_scraper.kois.repository import (
+    create_digest_item,
+    delete_unsent_digest_items,
+    mark_digest_sent,
+)
 from job_scraper.kois.schema import OpportunityCluster, ReviewStatus
 from job_scraper.slack_poster import SlackPoster
 
@@ -65,7 +69,13 @@ def send_digest_items(
     channel: str,
 ) -> list[dict]:
     sent_payloads: list[dict] = []
-    for cluster in select_digest_candidates(clusters):
+    for cluster in clusters:
+        if cluster.review_status in (ReviewStatus.IGNORED, ReviewStatus.WATCH_ONLY):
+            delete_unsent_digest_items(session, cluster)
+            continue
+        if cluster.review_status == ReviewStatus.NEEDS_REVIEW and cluster.confidence < 0.75:
+            continue
+
         payload = cluster_to_payload(cluster)
         digest_item = create_digest_item(
             session=session,

--- a/job_scraper/kois/digest.py
+++ b/job_scraper/kois/digest.py
@@ -21,11 +21,23 @@ class DigestPayload:
     cluster_id: int
 
 
+def _resolve_cluster_deadline(cluster: OpportunityCluster) -> str | None:
+    if not cluster.sources:
+        return None
+
+    if cluster.primary_source_record_id is not None:
+        for source in cluster.sources:
+            if source.extracted_record_id == cluster.primary_source_record_id:
+                return source.record.deadline
+
+    return cluster.sources[0].record.deadline
+
+
 def cluster_to_payload(cluster: OpportunityCluster) -> DigestPayload:
     return DigestPayload(
         title=cluster.title or "Untitled opportunity",
         customer=cluster.customer,
-        deadline=cluster.sources[0].record.deadline if cluster.sources else None,
+        deadline=_resolve_cluster_deadline(cluster),
         source_count=len(cluster.sources),
         primary_source_record_id=cluster.primary_source_record_id,
         confidence=cluster.confidence,

--- a/job_scraper/kois/domain.py
+++ b/job_scraper/kois/domain.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+
+@dataclass
+class RawIngestionItem:
+    source_type: str
+    source_name: str
+    external_id: str
+    raw_body: str
+    metadata: dict = field(default_factory=dict)
+    received_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))

--- a/job_scraper/kois/extraction.py
+++ b/job_scraper/kois/extraction.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse
 
 from job_scraper.models import Job
 from job_scraper.kois.schema import RawSourceItem
-from job_scraper.kois.utils import normalize_text
+from job_scraper.kois.utils import normalize_text, normalize_url
 from job_scraper.summarizer import JobDescriptionSummarizer
 
 
@@ -75,7 +75,7 @@ class RecordExtractor:
 
 
 def make_cluster_key(payload: dict) -> str:
-    source_url = normalize_text(payload.get("source_url"))
+    source_url = normalize_url(payload.get("source_url"))
     if source_url:
         return source_url
 

--- a/job_scraper/kois/extraction.py
+++ b/job_scraper/kois/extraction.py
@@ -41,7 +41,11 @@ class RecordExtractor:
             "description": body,
             "summary": summary,
             "extraction_confidence": 0.65,
-            "extracted_data": {"source_type": "email", "metadata": metadata},
+            "extracted_data": {
+                "source_type": "email",
+                "metadata": metadata,
+                "raw_content_hash": raw_source.content_hash,
+            },
         }
 
     def _extract_scraper(self, raw_source: RawSourceItem) -> dict:
@@ -64,6 +68,7 @@ class RecordExtractor:
                 "source_type": "scraper",
                 "platform": job.platform,
                 "host": urlparse(job.job_overview.job_uri or "").hostname,
+                "raw_content_hash": raw_source.content_hash,
             },
         }
 

--- a/job_scraper/kois/extraction.py
+++ b/job_scraper/kois/extraction.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import re
+from urllib.parse import urlparse
+
+from job_scraper.models import Job
+from job_scraper.kois.schema import RawSourceItem
+from job_scraper.kois.utils import normalize_text
+from job_scraper.summarizer import JobDescriptionSummarizer
+
+
+TITLE_PATTERN = re.compile(r"(oppdrag|assignment|rolle)[:\-]\s*(.+)", re.IGNORECASE)
+DEADLINE_PATTERN = re.compile(r"(frist|deadline)[:\-]\s*([^\n]+)", re.IGNORECASE)
+URL_PATTERN = re.compile(r"https?://[^\s)]+")
+
+
+class RecordExtractor:
+    def __init__(self, summarizer: JobDescriptionSummarizer | None = None):
+        self.summarizer = summarizer
+
+    def _extract_email(self, raw_source: RawSourceItem) -> dict:
+        body = raw_source.raw_body
+        metadata = raw_source.metadata_json or {}
+        subject = metadata.get("subject")
+
+        title_match = TITLE_PATTERN.search(subject or "") or TITLE_PATTERN.search(body)
+        deadline_match = DEADLINE_PATTERN.search(body)
+        url_match = URL_PATTERN.search(body)
+
+        summary = None
+        if self.summarizer:
+            summary = self.summarizer.summarize(body)
+
+        return {
+            "raw_source_item_id": raw_source.id,
+            "title": title_match.group(2).strip() if title_match else subject,
+            "customer": metadata.get("from"),
+            "broker": metadata.get("from"),
+            "source_url": url_match.group(0) if url_match else None,
+            "deadline": deadline_match.group(2).strip() if deadline_match else None,
+            "description": body,
+            "summary": summary,
+            "extraction_confidence": 0.65,
+            "extracted_data": {"source_type": "email", "metadata": metadata},
+        }
+
+    def _extract_scraper(self, raw_source: RawSourceItem) -> dict:
+        job = Job.model_validate_json(raw_source.raw_body)
+        description = job.description or ""
+        summary = job.description_summarised
+        if not summary and self.summarizer:
+            summary = self.summarizer.summarize(description)
+        return {
+            "raw_source_item_id": raw_source.id,
+            "title": job.job_overview.title,
+            "customer": job.job_overview.company,
+            "broker": job.platform,
+            "source_url": job.job_overview.job_uri,
+            "deadline": job.job_overview.delivery_date,
+            "description": description,
+            "summary": summary,
+            "extraction_confidence": 0.9,
+            "extracted_data": {
+                "source_type": "scraper",
+                "platform": job.platform,
+                "host": urlparse(job.job_overview.job_uri or "").hostname,
+            },
+        }
+
+    def extract(self, raw_source: RawSourceItem) -> dict:
+        if raw_source.source_type == "email":
+            return self._extract_email(raw_source)
+
+        return self._extract_scraper(raw_source)
+
+
+def make_cluster_key(payload: dict) -> str:
+    source_url = normalize_text(payload.get("source_url"))
+    if source_url:
+        return source_url
+
+    title = normalize_text(payload.get("title"))
+    customer = normalize_text(payload.get("customer"))
+    deadline = normalize_text(payload.get("deadline"))
+    return "|".join([title, customer, deadline])

--- a/job_scraper/kois/ingestion/__init__.py
+++ b/job_scraper/kois/ingestion/__init__.py
@@ -1,0 +1,1 @@
+"""Ingestion adapters for KOIS."""

--- a/job_scraper/kois/ingestion/imap_adapter.py
+++ b/job_scraper/kois/ingestion/imap_adapter.py
@@ -35,6 +35,20 @@ def _message_body(message: email.message.Message) -> str:
     return content.decode(message.get_content_charset() or "utf-8", errors="ignore")
 
 
+def _extract_rfc822_bytes(payload) -> bytes | None:
+    if not payload:
+        return None
+
+    for part in payload:
+        if isinstance(part, tuple) and len(part) >= 2:
+            body = part[1]
+            if isinstance(body, bytes):
+                return body
+        elif isinstance(part, bytes):
+            return part
+    return None
+
+
 def fetch_imap_items(settings: KOISSettings) -> list[RawIngestionItem]:
     if not settings.imap_host or not settings.imap_username or not settings.imap_password:
         return []
@@ -53,7 +67,9 @@ def fetch_imap_items(settings: KOISSettings) -> list[RawIngestionItem]:
             if fetch_status != "OK" or not payload:
                 continue
 
-            raw_email = payload[0][1]
+            raw_email = _extract_rfc822_bytes(payload)
+            if raw_email is None:
+                continue
             message = email.message_from_bytes(raw_email)
             message_id = message.get("Message-ID", uid.decode("utf-8"))
             body = _message_body(message)

--- a/job_scraper/kois/ingestion/imap_adapter.py
+++ b/job_scraper/kois/ingestion/imap_adapter.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import email
+import imaplib
+from datetime import datetime, timezone
+from email.header import decode_header
+
+from job_scraper.kois.config import KOISSettings
+from job_scraper.kois.domain import RawIngestionItem
+
+
+def _decode_header(value: str | None) -> str:
+    if not value:
+        return ""
+    parts = decode_header(value)
+    decoded = []
+    for payload, encoding in parts:
+        if isinstance(payload, bytes):
+            decoded.append(payload.decode(encoding or "utf-8", errors="ignore"))
+        else:
+            decoded.append(payload)
+    return "".join(decoded)
+
+
+def _message_body(message: email.message.Message) -> str:
+    if message.is_multipart():
+        chunks = []
+        for part in message.walk():
+            if part.get_content_type() == "text/plain":
+                content = part.get_payload(decode=True) or b""
+                chunks.append(content.decode(part.get_content_charset() or "utf-8", errors="ignore"))
+        return "\n".join(chunks)
+
+    content = message.get_payload(decode=True) or b""
+    return content.decode(message.get_content_charset() or "utf-8", errors="ignore")
+
+
+def fetch_imap_items(settings: KOISSettings) -> list[RawIngestionItem]:
+    if not settings.imap_host or not settings.imap_username or not settings.imap_password:
+        return []
+
+    raw_items: list[RawIngestionItem] = []
+    connection = imaplib.IMAP4_SSL(settings.imap_host, settings.imap_port)
+    try:
+        connection.login(settings.imap_username, settings.imap_password)
+        connection.select(settings.imap_mailbox)
+        status, response = connection.uid("SEARCH", None, f"UID {settings.imap_since_uid}:*")
+        if status != "OK" or not response or not response[0]:
+            return raw_items
+
+        for uid in response[0].split():
+            fetch_status, payload = connection.uid("FETCH", uid, "(RFC822)")
+            if fetch_status != "OK" or not payload:
+                continue
+
+            raw_email = payload[0][1]
+            message = email.message_from_bytes(raw_email)
+            message_id = message.get("Message-ID", uid.decode("utf-8"))
+            body = _message_body(message)
+            subject = _decode_header(message.get("Subject"))
+            metadata = {
+                "uid": uid.decode("utf-8"),
+                "subject": subject,
+                "from": _decode_header(message.get("From")),
+                "to": _decode_header(message.get("To")),
+                "cc": _decode_header(message.get("Cc")),
+                "date": _decode_header(message.get("Date")),
+                "mailbox": settings.imap_mailbox,
+                "message_id": message_id,
+            }
+            raw_items.append(
+                RawIngestionItem(
+                    source_type="email",
+                    source_name=settings.imap_source_name,
+                    external_id=message_id,
+                    raw_body=body,
+                    metadata=metadata,
+                    received_at=datetime.now(timezone.utc),
+                )
+            )
+    finally:
+        connection.logout()
+
+    return raw_items

--- a/job_scraper/kois/ingestion/scraper_adapter.py
+++ b/job_scraper/kois/ingestion/scraper_adapter.py
@@ -1,0 +1,30 @@
+from datetime import datetime, timezone
+from typing import Iterable
+
+from job_scraper.kois.domain import RawIngestionItem
+from job_scraper.models import Job
+
+
+def jobs_to_raw_items(jobs: Iterable[Job]) -> list[RawIngestionItem]:
+    raw_items: list[RawIngestionItem] = []
+    now = datetime.now(timezone.utc)
+    for job in jobs:
+        external_id = job.job_overview.job_uri or f"{job.platform}:{job.job_overview.title}"
+        metadata = {
+            "title": job.job_overview.title,
+            "company": job.job_overview.company,
+            "delivery_date": job.job_overview.delivery_date,
+            "job_uri": job.job_overview.job_uri,
+            "platform": job.platform,
+        }
+        raw_items.append(
+            RawIngestionItem(
+                source_type="scraper",
+                source_name=job.platform or "unknown",
+                external_id=external_id,
+                raw_body=job.model_dump_json(),
+                metadata=metadata,
+                received_at=now,
+            )
+        )
+    return raw_items

--- a/job_scraper/kois/ingestion/scraper_adapter.py
+++ b/job_scraper/kois/ingestion/scraper_adapter.py
@@ -2,14 +2,24 @@ from datetime import datetime, timezone
 from typing import Iterable
 
 from job_scraper.kois.domain import RawIngestionItem
+from job_scraper.kois.utils import content_hash, normalize_text
 from job_scraper.models import Job
+
+
+def _fallback_external_id(job: Job) -> str:
+    platform = normalize_text(job.platform) or "unknown"
+    title = normalize_text(job.job_overview.title) or "untitled"
+    company = normalize_text(job.job_overview.company) or "unknown-company"
+    deadline = normalize_text(job.job_overview.delivery_date) or "unknown-deadline"
+    body_fingerprint = content_hash(job.model_dump_json())[:16]
+    return f"fallback:{platform}:{title}:{company}:{deadline}:{body_fingerprint}"
 
 
 def jobs_to_raw_items(jobs: Iterable[Job]) -> list[RawIngestionItem]:
     raw_items: list[RawIngestionItem] = []
     now = datetime.now(timezone.utc)
     for job in jobs:
-        external_id = job.job_overview.job_uri or f"{job.platform}:{job.job_overview.title}"
+        external_id = job.job_overview.job_uri or _fallback_external_id(job)
         metadata = {
             "title": job.job_overview.title,
             "company": job.job_overview.company,

--- a/job_scraper/kois/migrations.py
+++ b/job_scraper/kois/migrations.py
@@ -1,0 +1,37 @@
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from job_scraper.kois.db import Base
+from job_scraper.kois import schema  # noqa: F401
+
+MIGRATION_ID = "20260605_kois_phase1_init"
+
+
+def run_migrations(engine: Engine) -> None:
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                CREATE TABLE IF NOT EXISTS kois_schema_migrations (
+                    migration_id TEXT PRIMARY KEY,
+                    applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                )
+                """
+            )
+        )
+        applied = connection.execute(
+            text(
+                "SELECT migration_id FROM kois_schema_migrations WHERE migration_id = :migration_id"
+            ),
+            {"migration_id": MIGRATION_ID},
+        ).first()
+        if applied:
+            return
+
+        Base.metadata.create_all(bind=connection)
+        connection.execute(
+            text(
+                "INSERT INTO kois_schema_migrations (migration_id) VALUES (:migration_id)"
+            ),
+            {"migration_id": MIGRATION_ID},
+        )

--- a/job_scraper/kois/migrations.py
+++ b/job_scraper/kois/migrations.py
@@ -1,37 +1,70 @@
+from collections.abc import Callable
+
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
 
 from job_scraper.kois.db import Base
 from job_scraper.kois import schema  # noqa: F401
 
-MIGRATION_ID = "20260605_kois_phase1_init"
+INIT_MIGRATION_ID = "20260605_kois_phase1_init"
+DROP_CONTENT_HASH_UNIQUE_MIGRATION_ID = "20260606_drop_raw_source_content_hash_unique"
+
+
+def _ensure_migrations_table(connection) -> None:
+    connection.execute(
+        text(
+            """
+            CREATE TABLE IF NOT EXISTS kois_schema_migrations (
+                migration_id TEXT PRIMARY KEY,
+                applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+            """
+        )
+    )
+
+
+def _is_applied(connection, migration_id: str) -> bool:
+    return (
+        connection.execute(
+            text(
+                "SELECT migration_id FROM kois_schema_migrations WHERE migration_id = :migration_id"
+            ),
+            {"migration_id": migration_id},
+        ).first()
+        is not None
+    )
+
+
+def _mark_applied(connection, migration_id: str) -> None:
+    connection.execute(
+        text("INSERT INTO kois_schema_migrations (migration_id) VALUES (:migration_id)"),
+        {"migration_id": migration_id},
+    )
+
+
+def _run_init(connection) -> None:
+    Base.metadata.create_all(bind=connection)
+
+
+def _drop_content_hash_unique(connection) -> None:
+    connection.execute(
+        text(
+            "ALTER TABLE raw_source_items DROP CONSTRAINT IF EXISTS uq_raw_source_content_hash"
+        )
+    )
+
+
+MIGRATIONS: list[tuple[str, Callable]] = [
+    (INIT_MIGRATION_ID, _run_init),
+    (DROP_CONTENT_HASH_UNIQUE_MIGRATION_ID, _drop_content_hash_unique),
+]
 
 
 def run_migrations(engine: Engine) -> None:
     with engine.begin() as connection:
-        connection.execute(
-            text(
-                """
-                CREATE TABLE IF NOT EXISTS kois_schema_migrations (
-                    migration_id TEXT PRIMARY KEY,
-                    applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-                )
-                """
-            )
-        )
-        applied = connection.execute(
-            text(
-                "SELECT migration_id FROM kois_schema_migrations WHERE migration_id = :migration_id"
-            ),
-            {"migration_id": MIGRATION_ID},
-        ).first()
-        if applied:
-            return
-
-        Base.metadata.create_all(bind=connection)
-        connection.execute(
-            text(
-                "INSERT INTO kois_schema_migrations (migration_id) VALUES (:migration_id)"
-            ),
-            {"migration_id": MIGRATION_ID},
-        )
+        _ensure_migrations_table(connection)
+        for migration_id, migration_fn in MIGRATIONS:
+            if _is_applied(connection, migration_id):
+                continue
+            migration_fn(connection)
+            _mark_applied(connection, migration_id)

--- a/job_scraper/kois/orchestrator.py
+++ b/job_scraper/kois/orchestrator.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 
 from sqlalchemy.orm import Session
 
-from job_scraper.kois.clustering import cluster_records
+from job_scraper.kois.clustering import cluster_records, refresh_clusters
 from job_scraper.kois.config import get_settings
 from job_scraper.kois.digest import send_digest_items
 from job_scraper.kois.domain import RawIngestionItem
@@ -14,6 +14,7 @@ from job_scraper.kois.ingestion.imap_adapter import fetch_imap_items
 from job_scraper.kois.ingestion.scraper_adapter import jobs_to_raw_items
 from job_scraper.kois.repository import (
     create_extracted_record,
+    detach_record_cluster_sources,
     get_extracted_record_for_raw_source,
     list_clusters_with_unsent_digests,
     upsert_raw_source_item,
@@ -48,6 +49,7 @@ def run_kois_pipeline(
     )
     extractor = RecordExtractor(summarizer=summarizer)
     records = []
+    clusters_from_failed_extraction: list = []
     for raw_item in raw_items:
         existing_record = get_extracted_record_for_raw_source(session, raw_item.id)
         if existing_record and _record_matches_raw_content(raw_item, existing_record):
@@ -61,8 +63,15 @@ def run_kois_pipeline(
             logger.exception("Extraction failed for raw source %s", raw_item.id)
             raw_item.extraction_error = str(exc)
             session.flush()
+            if existing_record is not None:
+                clusters_from_failed_extraction.extend(
+                    detach_record_cluster_sources(session, existing_record)
+                )
 
     touched_clusters = cluster_records(session, records)
+    if clusters_from_failed_extraction:
+        refresh_clusters(session, clusters_from_failed_extraction)
+        touched_clusters = [*touched_clusters, *clusters_from_failed_extraction]
     pending_clusters = list_clusters_with_unsent_digests(session)
     clusters = list(
         {cluster.id: cluster for cluster in [*touched_clusters, *pending_clusters]}.values()

--- a/job_scraper/kois/orchestrator.py
+++ b/job_scraper/kois/orchestrator.py
@@ -15,6 +15,7 @@ from job_scraper.kois.ingestion.scraper_adapter import jobs_to_raw_items
 from job_scraper.kois.repository import (
     create_extracted_record,
     get_extracted_record_for_raw_source,
+    list_clusters_with_unsent_digests,
     upsert_raw_source_item,
 )
 from job_scraper.models import Job
@@ -61,7 +62,11 @@ def run_kois_pipeline(
             raw_item.extraction_error = str(exc)
             session.flush()
 
-    clusters = cluster_records(session, records)
+    touched_clusters = cluster_records(session, records)
+    pending_clusters = list_clusters_with_unsent_digests(session)
+    clusters = list(
+        {cluster.id: cluster for cluster in [*touched_clusters, *pending_clusters]}.values()
+    )
     slack = SlackPoster(optional=True)
     digests = send_digest_items(
         session=session,
@@ -74,6 +79,6 @@ def run_kois_pipeline(
     return {
         "raw_items": len(raw_items),
         "records": len(records),
-        "clusters": len({cluster.id for cluster in clusters}),
+        "clusters": len({cluster.id for cluster in touched_clusters}),
         "digests": len(digests),
     }

--- a/job_scraper/kois/orchestrator.py
+++ b/job_scraper/kois/orchestrator.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+
+from sqlalchemy.orm import Session
+
+from job_scraper.kois.clustering import cluster_records
+from job_scraper.kois.config import get_settings
+from job_scraper.kois.digest import send_digest_items
+from job_scraper.kois.domain import RawIngestionItem
+from job_scraper.kois.extraction import RecordExtractor
+from job_scraper.kois.ingestion.imap_adapter import fetch_imap_items
+from job_scraper.kois.ingestion.scraper_adapter import jobs_to_raw_items
+from job_scraper.kois.repository import create_extracted_record, upsert_raw_source_item
+from job_scraper.models import Job
+from job_scraper.slack_poster import SlackPoster
+from job_scraper.summarizer import JobDescriptionSummarizer
+
+logger = logging.getLogger(__name__)
+
+
+def run_kois_pipeline(
+    session: Session,
+    scraped_jobs: Iterable[Job],
+) -> dict:
+    settings = get_settings()
+    ingestion_items: list[RawIngestionItem] = []
+    ingestion_items.extend(jobs_to_raw_items(scraped_jobs))
+    ingestion_items.extend(fetch_imap_items(settings))
+
+    raw_items = [upsert_raw_source_item(session, item) for item in ingestion_items]
+
+    summarizer = (
+        JobDescriptionSummarizer(optional=True)
+        if settings.gemini_api_key
+        else None
+    )
+    extractor = RecordExtractor(summarizer=summarizer)
+    records = []
+    for raw_item in raw_items:
+        try:
+            payload = extractor.extract(raw_item)
+            record = create_extracted_record(session, payload)
+            records.append(record)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Extraction failed for raw source %s", raw_item.id)
+            raw_item.extraction_error = str(exc)
+            session.flush()
+
+    clusters = cluster_records(session, records)
+    slack = SlackPoster(optional=True)
+    digests = send_digest_items(
+        session=session,
+        clusters=clusters,
+        slack=slack,
+        live_posting=settings.run_live_slack,
+        channel=settings.slack_channel,
+    )
+    session.commit()
+    return {
+        "raw_items": len(raw_items),
+        "records": len(records),
+        "clusters": len({cluster.id for cluster in clusters}),
+        "digests": len(digests),
+    }

--- a/job_scraper/kois/orchestrator.py
+++ b/job_scraper/kois/orchestrator.py
@@ -12,7 +12,11 @@ from job_scraper.kois.domain import RawIngestionItem
 from job_scraper.kois.extraction import RecordExtractor
 from job_scraper.kois.ingestion.imap_adapter import fetch_imap_items
 from job_scraper.kois.ingestion.scraper_adapter import jobs_to_raw_items
-from job_scraper.kois.repository import create_extracted_record, upsert_raw_source_item
+from job_scraper.kois.repository import (
+    create_extracted_record,
+    get_extracted_record_for_raw_source,
+    upsert_raw_source_item,
+)
 from job_scraper.models import Job
 from job_scraper.slack_poster import SlackPoster
 from job_scraper.summarizer import JobDescriptionSummarizer
@@ -39,6 +43,10 @@ def run_kois_pipeline(
     extractor = RecordExtractor(summarizer=summarizer)
     records = []
     for raw_item in raw_items:
+        existing_record = get_extracted_record_for_raw_source(session, raw_item.id)
+        if existing_record:
+            records.append(existing_record)
+            continue
         try:
             payload = extractor.extract(raw_item)
             record = create_extracted_record(session, payload)

--- a/job_scraper/kois/orchestrator.py
+++ b/job_scraper/kois/orchestrator.py
@@ -24,6 +24,11 @@ from job_scraper.summarizer import JobDescriptionSummarizer
 logger = logging.getLogger(__name__)
 
 
+def _record_matches_raw_content(raw_item, record) -> bool:
+    extracted_data = record.extracted_data or {}
+    return extracted_data.get("raw_content_hash") == raw_item.content_hash
+
+
 def run_kois_pipeline(
     session: Session,
     scraped_jobs: Iterable[Job],
@@ -44,7 +49,7 @@ def run_kois_pipeline(
     records = []
     for raw_item in raw_items:
         existing_record = get_extracted_record_for_raw_source(session, raw_item.id)
-        if existing_record:
+        if existing_record and _record_matches_raw_content(raw_item, existing_record):
             records.append(existing_record)
             continue
         try:

--- a/job_scraper/kois/repository.py
+++ b/job_scraper/kois/repository.py
@@ -41,6 +41,17 @@ def upsert_raw_source_item(session: Session, item: RawIngestionItem) -> RawSourc
     return raw
 
 
+def get_extracted_record_for_raw_source(
+    session: Session, raw_source_item_id: int
+) -> ExtractedRecord | None:
+    return session.execute(
+        select(ExtractedRecord)
+        .where(ExtractedRecord.raw_source_item_id == raw_source_item_id)
+        .order_by(ExtractedRecord.id.desc())
+        .limit(1)
+    ).scalar_one_or_none()
+
+
 def create_extracted_record(session: Session, payload: dict) -> ExtractedRecord:
     record = ExtractedRecord(**payload)
     session.add(record)

--- a/job_scraper/kois/repository.py
+++ b/job_scraper/kois/repository.py
@@ -235,6 +235,18 @@ def mark_digest_sent(session: Session, item: DigestItem, slack_ts: str | None) -
     session.flush()
 
 
+def delete_unsent_digest_items(session: Session, cluster: OpportunityCluster) -> None:
+    unsent_items = session.execute(
+        select(DigestItem).where(
+            DigestItem.opportunity_cluster_id == cluster.id,
+            DigestItem.sent_at.is_(None),
+        )
+    ).scalars()
+    for item in unsent_items:
+        session.delete(item)
+    session.flush()
+
+
 def list_clusters_with_unsent_digests(session: Session) -> list[OpportunityCluster]:
     return list(
         session.execute(

--- a/job_scraper/kois/repository.py
+++ b/job_scraper/kois/repository.py
@@ -151,6 +151,30 @@ def attach_cluster_source(
     return source
 
 
+def detach_superseded_cluster_sources(
+    session: Session, record: ExtractedRecord
+) -> list[OpportunityCluster]:
+    stale_links = list(
+        session.execute(
+            select(ClusterSource)
+            .join(ExtractedRecord)
+            .where(
+                ExtractedRecord.raw_source_item_id == record.raw_source_item_id,
+                ClusterSource.extracted_record_id != record.id,
+            )
+        ).scalars()
+    )
+    affected_clusters = []
+    for link in stale_links:
+        affected_clusters.append(link.cluster)
+        session.delete(link)
+    if stale_links:
+        session.flush()
+        for cluster in affected_clusters:
+            session.expire(cluster, ["sources"])
+    return affected_clusters
+
+
 def create_source_comparison(
     session: Session, cluster: OpportunityCluster, field_name: str, values: dict
 ) -> SourceComparison:

--- a/job_scraper/kois/repository.py
+++ b/job_scraper/kois/repository.py
@@ -176,14 +176,31 @@ def create_digest_item(
     status: ReviewStatus,
     payload: dict,
 ) -> DigestItem:
-    existing = session.execute(
+    existing_unsent = session.execute(
+        select(DigestItem)
+        .where(
+            DigestItem.opportunity_cluster_id == cluster.id,
+            DigestItem.sent_at.is_(None),
+        )
+        .order_by(DigestItem.id.desc())
+        .limit(1)
+    ).scalar_one_or_none()
+    if existing_unsent:
+        existing_unsent.review_status = status
+        existing_unsent.payload_json = payload
+        session.flush()
+        return existing_unsent
+
+    existing_sent = session.execute(
         select(DigestItem).where(
             DigestItem.opportunity_cluster_id == cluster.id,
-            DigestItem.review_status == status,
+            DigestItem.sent_at.is_not(None),
         )
+        .order_by(DigestItem.sent_at.desc(), DigestItem.id.desc())
+        .limit(1)
     ).scalar_one_or_none()
-    if existing:
-        return existing
+    if existing_sent:
+        return existing_sent
 
     item = DigestItem(
         opportunity_cluster_id=cluster.id,

--- a/job_scraper/kois/repository.py
+++ b/job_scraper/kois/repository.py
@@ -133,6 +133,25 @@ def attach_cluster_source(
     return source
 
 
+def detach_record_cluster_sources(
+    session: Session, record: ExtractedRecord
+) -> list[OpportunityCluster]:
+    links = list(
+        session.execute(
+            select(ClusterSource).where(ClusterSource.extracted_record_id == record.id)
+        ).scalars()
+    )
+    affected_clusters = []
+    for link in links:
+        affected_clusters.append(link.cluster)
+        session.delete(link)
+    if links:
+        session.flush()
+        for cluster in affected_clusters:
+            session.expire(cluster, ["sources"])
+    return affected_clusters
+
+
 def detach_superseded_cluster_sources(
     session: Session, record: ExtractedRecord
 ) -> list[OpportunityCluster]:

--- a/job_scraper/kois/repository.py
+++ b/job_scraper/kois/repository.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from job_scraper.kois.domain import RawIngestionItem
+from job_scraper.kois.schema import (
+    ClusterSource,
+    DigestItem,
+    ExtractedRecord,
+    OpportunityCluster,
+    RawSourceItem,
+    ReviewState,
+    ReviewStatus,
+    SourceComparison,
+)
+from job_scraper.kois.utils import content_hash
+
+
+def upsert_raw_source_item(session: Session, item: RawIngestionItem) -> RawSourceItem:
+    item_hash = content_hash(item.raw_body)
+    existing = session.execute(
+        select(RawSourceItem).where(RawSourceItem.content_hash == item_hash)
+    ).scalar_one_or_none()
+    if existing:
+        return existing
+
+    raw = RawSourceItem(
+        source_type=item.source_type,
+        source_name=item.source_name,
+        external_id=item.external_id,
+        content_hash=item_hash,
+        received_at=item.received_at,
+        raw_body=item.raw_body,
+        metadata_json=item.metadata,
+    )
+    session.add(raw)
+    session.flush()
+    return raw
+
+
+def create_extracted_record(session: Session, payload: dict) -> ExtractedRecord:
+    record = ExtractedRecord(**payload)
+    session.add(record)
+    session.flush()
+    return record
+
+
+def create_or_update_cluster(
+    session: Session,
+    cluster_key: str,
+    title: str | None,
+    customer: str | None,
+    confidence: float,
+    review_status: ReviewStatus,
+) -> OpportunityCluster:
+    cluster = session.execute(
+        select(OpportunityCluster).where(OpportunityCluster.cluster_key == cluster_key)
+    ).scalar_one_or_none()
+    if cluster:
+        cluster.title = cluster.title or title
+        cluster.customer = cluster.customer or customer
+        cluster.confidence = max(cluster.confidence, confidence)
+        cluster.review_status = review_status
+        session.flush()
+        return cluster
+
+    cluster = OpportunityCluster(
+        cluster_key=cluster_key,
+        title=title,
+        customer=customer,
+        confidence=confidence,
+        review_status=review_status,
+    )
+    session.add(cluster)
+    session.flush()
+    return cluster
+
+
+def attach_cluster_source(
+    session: Session,
+    cluster: OpportunityCluster,
+    record: ExtractedRecord,
+    confidence: float,
+    rationale: str,
+) -> ClusterSource:
+    existing = session.execute(
+        select(ClusterSource).where(
+            ClusterSource.opportunity_cluster_id == cluster.id,
+            ClusterSource.extracted_record_id == record.id,
+        )
+    ).scalar_one_or_none()
+    if existing:
+        return existing
+
+    source = ClusterSource(
+        opportunity_cluster_id=cluster.id,
+        extracted_record_id=record.id,
+        match_confidence=confidence,
+        match_rationale=rationale,
+    )
+    session.add(source)
+    session.flush()
+    return source
+
+
+def create_source_comparison(
+    session: Session, cluster: OpportunityCluster, field_name: str, values: dict
+) -> SourceComparison:
+    comparison = SourceComparison(
+        opportunity_cluster_id=cluster.id,
+        field_name=field_name,
+        values_json=values,
+    )
+    session.add(comparison)
+    session.flush()
+    return comparison
+
+
+def create_review_state(
+    session: Session,
+    cluster: OpportunityCluster,
+    status: ReviewStatus,
+    actor: str = "system",
+    note: str | None = None,
+) -> ReviewState:
+    review = ReviewState(
+        opportunity_cluster_id=cluster.id,
+        status=status,
+        actor=actor,
+        note=note,
+    )
+    session.add(review)
+    session.flush()
+    cluster.review_status = status
+    return review
+
+
+def create_digest_item(
+    session: Session,
+    cluster: OpportunityCluster,
+    status: ReviewStatus,
+    payload: dict,
+) -> DigestItem:
+    existing = session.execute(
+        select(DigestItem).where(
+            DigestItem.opportunity_cluster_id == cluster.id,
+            DigestItem.review_status == status,
+        )
+    ).scalar_one_or_none()
+    if existing:
+        return existing
+
+    item = DigestItem(
+        opportunity_cluster_id=cluster.id,
+        review_status=status,
+        payload_json=payload,
+    )
+    session.add(item)
+    session.flush()
+    return item
+
+
+def mark_digest_sent(session: Session, item: DigestItem, slack_ts: str | None) -> None:
+    item.slack_message_ts = slack_ts
+    item.sent_at = datetime.now(timezone.utc)
+    session.flush()

--- a/job_scraper/kois/repository.py
+++ b/job_scraper/kois/repository.py
@@ -25,11 +25,21 @@ AUTOMATED_REVIEW_STATUSES = frozenset(
 
 def upsert_raw_source_item(session: Session, item: RawIngestionItem) -> RawSourceItem:
     item_hash = content_hash(item.raw_body)
-    existing = session.execute(
+    existing_by_external_id = session.execute(
+        select(RawSourceItem).where(
+            RawSourceItem.source_type == item.source_type,
+            RawSourceItem.source_name == item.source_name,
+            RawSourceItem.external_id == item.external_id,
+        )
+    ).scalar_one_or_none()
+    if existing_by_external_id:
+        return existing_by_external_id
+
+    existing_by_hash = session.execute(
         select(RawSourceItem).where(RawSourceItem.content_hash == item_hash)
     ).scalar_one_or_none()
-    if existing:
-        return existing
+    if existing_by_hash:
+        return existing_by_hash
 
     raw = RawSourceItem(
         source_type=item.source_type,

--- a/job_scraper/kois/repository.py
+++ b/job_scraper/kois/repository.py
@@ -34,6 +34,18 @@ def upsert_raw_source_item(session: Session, item: RawIngestionItem) -> RawSourc
     ).scalar_one_or_none()
     if existing_by_external_id:
         if existing_by_external_id.content_hash != item_hash:
+            existing_by_hash = session.execute(
+                select(RawSourceItem).where(
+                    RawSourceItem.content_hash == item_hash,
+                    RawSourceItem.id != existing_by_external_id.id,
+                )
+            ).scalar_one_or_none()
+            if existing_by_hash:
+                existing_by_hash.received_at = item.received_at
+                existing_by_hash.metadata_json = item.metadata
+                existing_by_hash.extraction_error = None
+                session.flush()
+                return existing_by_hash
             existing_by_external_id.content_hash = item_hash
             existing_by_external_id.raw_body = item.raw_body
             existing_by_external_id.metadata_json = item.metadata

--- a/job_scraper/kois/repository.py
+++ b/job_scraper/kois/repository.py
@@ -34,18 +34,6 @@ def upsert_raw_source_item(session: Session, item: RawIngestionItem) -> RawSourc
     ).scalar_one_or_none()
     if existing_by_external_id:
         if existing_by_external_id.content_hash != item_hash:
-            existing_by_hash = session.execute(
-                select(RawSourceItem).where(
-                    RawSourceItem.content_hash == item_hash,
-                    RawSourceItem.id != existing_by_external_id.id,
-                )
-            ).scalar_one_or_none()
-            if existing_by_hash:
-                existing_by_hash.received_at = item.received_at
-                existing_by_hash.metadata_json = item.metadata
-                existing_by_hash.extraction_error = None
-                session.flush()
-                return existing_by_hash
             existing_by_external_id.content_hash = item_hash
             existing_by_external_id.raw_body = item.raw_body
             existing_by_external_id.metadata_json = item.metadata

--- a/job_scraper/kois/repository.py
+++ b/job_scraper/kois/repository.py
@@ -42,12 +42,6 @@ def upsert_raw_source_item(session: Session, item: RawIngestionItem) -> RawSourc
             session.flush()
         return existing_by_external_id
 
-    existing_by_hash = session.execute(
-        select(RawSourceItem).where(RawSourceItem.content_hash == item_hash)
-    ).scalar_one_or_none()
-    if existing_by_hash:
-        return existing_by_hash
-
     raw = RawSourceItem(
         source_type=item.source_type,
         source_name=item.source_name,

--- a/job_scraper/kois/repository.py
+++ b/job_scraper/kois/repository.py
@@ -18,6 +18,10 @@ from job_scraper.kois.schema import (
 )
 from job_scraper.kois.utils import content_hash
 
+AUTOMATED_REVIEW_STATUSES = frozenset(
+    {ReviewStatus.AUTO_ACCEPTED, ReviewStatus.NEEDS_REVIEW}
+)
+
 
 def upsert_raw_source_item(session: Session, item: RawIngestionItem) -> RawSourceItem:
     item_hash = content_hash(item.raw_body)
@@ -74,7 +78,8 @@ def create_or_update_cluster(
         cluster.title = cluster.title or title
         cluster.customer = cluster.customer or customer
         cluster.confidence = max(cluster.confidence, confidence)
-        cluster.review_status = review_status
+        if cluster.review_status in AUTOMATED_REVIEW_STATUSES:
+            cluster.review_status = review_status
         session.flush()
         return cluster
 

--- a/job_scraper/kois/repository.py
+++ b/job_scraper/kois/repository.py
@@ -33,6 +33,13 @@ def upsert_raw_source_item(session: Session, item: RawIngestionItem) -> RawSourc
         )
     ).scalar_one_or_none()
     if existing_by_external_id:
+        if existing_by_external_id.content_hash != item_hash:
+            existing_by_external_id.content_hash = item_hash
+            existing_by_external_id.raw_body = item.raw_body
+            existing_by_external_id.metadata_json = item.metadata
+            existing_by_external_id.received_at = item.received_at
+            existing_by_external_id.extraction_error = None
+            session.flush()
         return existing_by_external_id
 
     existing_by_hash = session.execute(

--- a/job_scraper/kois/repository.py
+++ b/job_scraper/kois/repository.py
@@ -233,3 +233,14 @@ def mark_digest_sent(session: Session, item: DigestItem, slack_ts: str | None) -
     item.slack_message_ts = slack_ts
     item.sent_at = datetime.now(timezone.utc)
     session.flush()
+
+
+def list_clusters_with_unsent_digests(session: Session) -> list[OpportunityCluster]:
+    return list(
+        session.execute(
+            select(OpportunityCluster)
+            .join(DigestItem, DigestItem.opportunity_cluster_id == OpportunityCluster.id)
+            .where(DigestItem.sent_at.is_(None))
+            .distinct()
+        ).scalars()
+    )

--- a/job_scraper/kois/repository.py
+++ b/job_scraper/kois/repository.py
@@ -135,6 +135,22 @@ def create_source_comparison(
     return comparison
 
 
+def upsert_source_comparison(
+    session: Session, cluster: OpportunityCluster, field_name: str, values: dict
+) -> SourceComparison:
+    comparison = session.execute(
+        select(SourceComparison).where(
+            SourceComparison.opportunity_cluster_id == cluster.id,
+            SourceComparison.field_name == field_name,
+        )
+    ).scalar_one_or_none()
+    if comparison:
+        comparison.values_json = values
+        session.flush()
+        return comparison
+    return create_source_comparison(session, cluster, field_name, values)
+
+
 def create_review_state(
     session: Session,
     cluster: OpportunityCluster,

--- a/job_scraper/kois/review.py
+++ b/job_scraper/kois/review.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from job_scraper.kois.repository import create_review_state
+from job_scraper.kois.schema import OpportunityCluster, ReviewStatus
+
+
+class ReviewService:
+    def __init__(self, session: Session):
+        self.session = session
+
+    def list_needs_review(self) -> list[OpportunityCluster]:
+        return list(
+            self.session.execute(
+                select(OpportunityCluster).where(
+                    OpportunityCluster.review_status == ReviewStatus.NEEDS_REVIEW
+                )
+            ).scalars()
+        )
+
+    def set_status(
+        self,
+        cluster_id: int,
+        status: ReviewStatus,
+        actor: str = "reviewer",
+        note: str | None = None,
+    ) -> OpportunityCluster:
+        cluster = self.session.get(OpportunityCluster, cluster_id)
+        if not cluster:
+            raise ValueError(f"Cluster {cluster_id} not found")
+        create_review_state(
+            session=self.session,
+            cluster=cluster,
+            status=status,
+            actor=actor,
+            note=note,
+        )
+        self.session.commit()
+        self.session.refresh(cluster)
+        return cluster

--- a/job_scraper/kois/review_api.py
+++ b/job_scraper/kois/review_api.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from fastapi import Depends, FastAPI, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import or_, select
+from sqlalchemy.orm import Session
+
+from job_scraper.kois.db import get_db_session
+from job_scraper.kois.review import ReviewService
+from job_scraper.kois.schema import OpportunityCluster, ReviewStatus
+
+app = FastAPI(title="KOIS Phase 1 Review API")
+
+
+class ReviewUpdate(BaseModel):
+    status: ReviewStatus
+    actor: str = "reviewer"
+    note: str | None = None
+
+
+@app.get("/health")
+def healthcheck():
+    return {"ok": True}
+
+
+@app.get("/clusters")
+def list_clusters(
+    status: ReviewStatus | None = None,
+    q: str | None = None,
+    session: Session = Depends(get_db_session),
+):
+    query = select(OpportunityCluster)
+    if status:
+        query = query.where(OpportunityCluster.review_status == status)
+    if q:
+        query = query.where(
+            or_(
+                OpportunityCluster.title.ilike(f"%{q}%"),
+                OpportunityCluster.customer.ilike(f"%{q}%"),
+                OpportunityCluster.cluster_key.ilike(f"%{q}%"),
+            )
+        )
+    clusters = list(session.execute(query).scalars())
+    return [
+        {
+            "id": cluster.id,
+            "cluster_key": cluster.cluster_key,
+            "title": cluster.title,
+            "customer": cluster.customer,
+            "review_status": cluster.review_status.value,
+            "confidence": cluster.confidence,
+            "source_count": len(cluster.sources),
+        }
+        for cluster in clusters
+    ]
+
+
+@app.get("/review-queue")
+def review_queue(session: Session = Depends(get_db_session)):
+    review_service = ReviewService(session)
+    clusters = review_service.list_needs_review()
+    return [
+        {
+            "id": cluster.id,
+            "title": cluster.title,
+            "customer": cluster.customer,
+            "confidence": cluster.confidence,
+            "comparisons": [
+                {"field": comparison.field_name, "values": comparison.values_json}
+                for comparison in cluster.comparisons
+            ],
+        }
+        for cluster in clusters
+    ]
+
+
+@app.patch("/clusters/{cluster_id}/status")
+def update_cluster_status(
+    cluster_id: int,
+    update: ReviewUpdate,
+    session: Session = Depends(get_db_session),
+):
+    review_service = ReviewService(session)
+    try:
+        cluster = review_service.set_status(
+            cluster_id=cluster_id,
+            status=update.status,
+            actor=update.actor,
+            note=update.note,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return {
+        "id": cluster.id,
+        "status": cluster.review_status.value,
+    }

--- a/job_scraper/kois/schema.py
+++ b/job_scraper/kois/schema.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import enum
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import JSON, DateTime, Enum, ForeignKey, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from job_scraper.kois.db import Base
+
+
+class ReviewStatus(str, enum.Enum):
+    AUTO_ACCEPTED = "auto_accepted"
+    NEEDS_REVIEW = "needs_review"
+    MANUALLY_MERGED = "manually_merged"
+    MANUALLY_SPLIT = "manually_split"
+    IGNORED = "ignored"
+    WATCH_ONLY = "watch_only"
+
+
+class RawSourceItem(Base):
+    __tablename__ = "raw_source_items"
+    __table_args__ = (
+        UniqueConstraint(
+            "source_type",
+            "source_name",
+            "external_id",
+            name="uq_raw_source_external_id",
+        ),
+        UniqueConstraint("content_hash", name="uq_raw_source_content_hash"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    source_type: Mapped[str] = mapped_column(String(32), index=True)
+    source_name: Mapped[str] = mapped_column(String(128), index=True)
+    external_id: Mapped[str] = mapped_column(String(512), index=True)
+    content_hash: Mapped[str] = mapped_column(String(128), index=True)
+    received_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    raw_body: Mapped[str] = mapped_column(Text)
+    metadata_json: Mapped[dict] = mapped_column("metadata", JSON, default=dict)
+    extraction_error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow
+    )
+
+    extracted_records: Mapped[list["ExtractedRecord"]] = relationship(
+        back_populates="raw_source", cascade="all, delete-orphan"
+    )
+
+
+class ExtractedRecord(Base):
+    __tablename__ = "extracted_records"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    raw_source_item_id: Mapped[int] = mapped_column(
+        ForeignKey("raw_source_items.id"), index=True
+    )
+    title: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
+    customer: Mapped[Optional[str]] = mapped_column(String(256), nullable=True)
+    broker: Mapped[Optional[str]] = mapped_column(String(256), nullable=True)
+    source_url: Mapped[Optional[str]] = mapped_column(String(1024), nullable=True)
+    deadline: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    summary: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    extracted_data: Mapped[dict] = mapped_column(JSON, default=dict)
+    extraction_confidence: Mapped[Optional[float]] = mapped_column(nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow
+    )
+
+    raw_source: Mapped[RawSourceItem] = relationship(back_populates="extracted_records")
+    cluster_links: Mapped[list["ClusterSource"]] = relationship(
+        back_populates="record", cascade="all, delete-orphan"
+    )
+
+
+class OpportunityCluster(Base):
+    __tablename__ = "opportunity_clusters"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    cluster_key: Mapped[str] = mapped_column(String(512), unique=True, index=True)
+    title: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
+    customer: Mapped[Optional[str]] = mapped_column(String(256), nullable=True)
+    primary_source_record_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("extracted_records.id"), nullable=True
+    )
+    review_status: Mapped[ReviewStatus] = mapped_column(
+        Enum(ReviewStatus), default=ReviewStatus.NEEDS_REVIEW, index=True
+    )
+    confidence: Mapped[float] = mapped_column(default=0.0)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    sources: Mapped[list["ClusterSource"]] = relationship(
+        back_populates="cluster", cascade="all, delete-orphan"
+    )
+    comparisons: Mapped[list["SourceComparison"]] = relationship(
+        back_populates="cluster", cascade="all, delete-orphan"
+    )
+    review_history: Mapped[list["ReviewState"]] = relationship(
+        back_populates="cluster", cascade="all, delete-orphan"
+    )
+    digest_items: Mapped[list["DigestItem"]] = relationship(
+        back_populates="cluster", cascade="all, delete-orphan"
+    )
+
+
+class ClusterSource(Base):
+    __tablename__ = "cluster_sources"
+    __table_args__ = (
+        UniqueConstraint(
+            "opportunity_cluster_id",
+            "extracted_record_id",
+            name="uq_cluster_source_record",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    opportunity_cluster_id: Mapped[int] = mapped_column(
+        ForeignKey("opportunity_clusters.id"), index=True
+    )
+    extracted_record_id: Mapped[int] = mapped_column(
+        ForeignKey("extracted_records.id"), index=True
+    )
+    match_confidence: Mapped[float] = mapped_column(default=0.0)
+    match_rationale: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    cluster: Mapped[OpportunityCluster] = relationship(back_populates="sources")
+    record: Mapped[ExtractedRecord] = relationship(back_populates="cluster_links")
+
+
+class SourceComparison(Base):
+    __tablename__ = "source_comparisons"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    opportunity_cluster_id: Mapped[int] = mapped_column(
+        ForeignKey("opportunity_clusters.id"), index=True
+    )
+    field_name: Mapped[str] = mapped_column(String(128))
+    values_json: Mapped[dict] = mapped_column("values", JSON, default=dict)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow
+    )
+
+    cluster: Mapped[OpportunityCluster] = relationship(back_populates="comparisons")
+
+
+class ReviewState(Base):
+    __tablename__ = "review_states"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    opportunity_cluster_id: Mapped[int] = mapped_column(
+        ForeignKey("opportunity_clusters.id"), index=True
+    )
+    status: Mapped[ReviewStatus] = mapped_column(Enum(ReviewStatus), index=True)
+    note: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    actor: Mapped[str] = mapped_column(String(128), default="system")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow
+    )
+
+    cluster: Mapped[OpportunityCluster] = relationship(back_populates="review_history")
+
+
+class DigestItem(Base):
+    __tablename__ = "digest_items"
+    __table_args__ = (
+        UniqueConstraint(
+            "opportunity_cluster_id",
+            "review_status",
+            name="uq_digest_cluster_status",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    opportunity_cluster_id: Mapped[int] = mapped_column(
+        ForeignKey("opportunity_clusters.id"), index=True
+    )
+    review_status: Mapped[ReviewStatus] = mapped_column(Enum(ReviewStatus), index=True)
+    payload_json: Mapped[dict] = mapped_column("payload", JSON, default=dict)
+    slack_message_ts: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    sent_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    cluster: Mapped[OpportunityCluster] = relationship(back_populates="digest_items")

--- a/job_scraper/kois/schema.py
+++ b/job_scraper/kois/schema.py
@@ -28,7 +28,6 @@ class RawSourceItem(Base):
             "external_id",
             name="uq_raw_source_external_id",
         ),
-        UniqueConstraint("content_hash", name="uq_raw_source_content_hash"),
     )
 
     id: Mapped[int] = mapped_column(primary_key=True)

--- a/job_scraper/kois/utils.py
+++ b/job_scraper/kois/utils.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import hashlib
+import re
+
+
+def content_hash(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def normalize_text(value: str | None) -> str:
+    if not value:
+        return ""
+    normalized = re.sub(r"\s+", " ", value.strip().lower())
+    return normalized
+
+
+def normalize_url(value: str | None) -> str:
+    if not value:
+        return ""
+    return normalize_text(value).rstrip("/")

--- a/job_scraper/main.py
+++ b/job_scraper/main.py
@@ -4,17 +4,15 @@ from playwright.async_api import Browser, async_playwright
 from typing import List
 from dotenv import load_dotenv
 
-from models import Job
-
-from scrapers.folq import FolqScraper
-from scrapers.verama import VeramaScraper
-from scrapers.mercell import MercellScraper
-from scrapers.emagine import EmagineScraper
-from scrapers.witted import WittedScraper
-
-from summarizer import JobDescriptionSummarizer
-from slack_poster import SlackPoster
-from new_job_detector import NewJobPostDetector
+from job_scraper.kois.db import SessionLocal, create_db_engine
+from job_scraper.kois.migrations import run_migrations
+from job_scraper.kois.orchestrator import run_kois_pipeline
+from job_scraper.models import Job
+from job_scraper.scrapers.emagine import EmagineScraper
+from job_scraper.scrapers.folq import FolqScraper
+from job_scraper.scrapers.mercell import MercellScraper
+from job_scraper.scrapers.verama import VeramaScraper
+from job_scraper.scrapers.witted import WittedScraper
 
 logging.basicConfig(level=logging.INFO)
 
@@ -47,22 +45,12 @@ async def run_scrapers() -> List[Job]:
 
 async def main():
     load_dotenv()
-
-    summarizer = JobDescriptionSummarizer()
     scraped_jobs: List[Job] = await run_scrapers()
-
-    slack_poster = SlackPoster()
-
-    change_detector = NewJobPostDetector("jobs.json")
-
-    new_jobs = change_detector.detect_new_jobs(scraped_jobs)
-    logging.info(f"Found {len(scraped_jobs)} jobs in total, {len(new_jobs)} are new.")
-
-    for job in new_jobs:
-        job.description_summarised = summarizer.summarize(job.description)
-        slack_poster.post_job(job)
-
-    change_detector.update_known_jobs(new_jobs)
+    engine = create_db_engine()
+    run_migrations(engine)
+    with SessionLocal() as session:
+        result = run_kois_pipeline(session=session, scraped_jobs=scraped_jobs)
+    logging.info("KOIS run complete: %s", result)
 
 
 if __name__ == "__main__":

--- a/job_scraper/models.py
+++ b/job_scraper/models.py
@@ -1,4 +1,5 @@
-from typing import TypeAlias
+from __future__ import annotations
+
 from pydantic import BaseModel, TypeAdapter, computed_field
 from pydantic.dataclasses import dataclass
 
@@ -23,5 +24,5 @@ class Job(BaseModel):
         return self.job_overview.job_uri
 
 
-JobList: TypeAlias = list[Job]
+JobList = list[Job]
 JobListModel = TypeAdapter(JobList)

--- a/job_scraper/new_job_detector.py
+++ b/job_scraper/new_job_detector.py
@@ -1,6 +1,6 @@
 import os
 from typing import List
-from models import Job, JobListModel
+from job_scraper.models import Job, JobListModel
 
 class NewJobPostDetector:
     """

--- a/job_scraper/scrapers/base.py
+++ b/job_scraper/scrapers/base.py
@@ -3,7 +3,7 @@ from playwright.async_api import Browser, Page, BrowserContext
 from abc import ABC, abstractmethod
 from typing import List
 
-from models import Job, JobOverview
+from job_scraper.models import Job, JobOverview
 
 import logging
 

--- a/job_scraper/scrapers/emagine.py
+++ b/job_scraper/scrapers/emagine.py
@@ -1,8 +1,8 @@
-from scrapers.base import JobScraper
+from job_scraper.scrapers.base import JobScraper
 from playwright.async_api import Page
 from typing import List
 
-from models import Job, JobOverview
+from job_scraper.models import Job, JobOverview
 
 
 class EmagineScraper(JobScraper):

--- a/job_scraper/scrapers/folq.py
+++ b/job_scraper/scrapers/folq.py
@@ -1,8 +1,8 @@
-from scrapers.base import JobScraper
+from job_scraper.scrapers.base import JobScraper
 from playwright.async_api import Page
 from typing import List
 
-from models import Job, JobOverview
+from job_scraper.models import Job, JobOverview
 
 import logging
 

--- a/job_scraper/scrapers/mercell.py
+++ b/job_scraper/scrapers/mercell.py
@@ -1,8 +1,10 @@
-from scrapers.base import JobScraper
+import logging
+
+from job_scraper.scrapers.base import JobScraper
 from playwright.async_api import Page
 from typing import List
 
-from models import Job, JobOverview
+from job_scraper.models import Job, JobOverview
 
 class MercellScraper(JobScraper):
     base_url = "https://my.mercell.com"

--- a/job_scraper/scrapers/verama.py
+++ b/job_scraper/scrapers/verama.py
@@ -1,8 +1,8 @@
-from scrapers.base import JobScraper
+from job_scraper.scrapers.base import JobScraper
 from playwright.async_api import Page
 from typing import List
 
-from models import Job, JobOverview
+from job_scraper.models import Job, JobOverview
 
 import logging
 

--- a/job_scraper/scrapers/witted.py
+++ b/job_scraper/scrapers/witted.py
@@ -1,8 +1,8 @@
-from scrapers.base import JobScraper
+from job_scraper.scrapers.base import JobScraper
 from playwright.async_api import Page
 from typing import List
 
-from models import Job, JobOverview
+from job_scraper.models import Job, JobOverview
 
 
 class WittedScraper(JobScraper):

--- a/job_scraper/slack_poster.py
+++ b/job_scraper/slack_poster.py
@@ -1,18 +1,23 @@
+from __future__ import annotations
+
 import os
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 from slack_sdk.models.blocks import HeaderBlock, SectionBlock, DividerBlock
 from slack_sdk.models.blocks.basic_components import PlainTextObject, MarkdownTextObject
 
-from models import Job
+from job_scraper.models import Job
 
 class SlackPoster:
     client: WebClient
 
-    def __init__(self):
+    def __init__(self, optional: bool = False):
         self.token = os.getenv("SLACK_TOKEN")
 
         if not self.token:
+            if optional:
+                self.client = None
+                return
             raise ValueError("Missing SLACK_TOKEN in environment.")
 
         self.client = WebClient(token=self.token)
@@ -54,12 +59,44 @@ class SlackPoster:
         Posts a single job to Slack.
         """
         text, blocks = self.create_job_slack_message(job)
+        if self.client is None:
+            return None
 
         try:
             response = self.client.chat_postMessage(
                 channel=channel, text=text, blocks=blocks
             )
             return response
+        except SlackApiError as e:
+            print(f"Slack API Error: {e.response['error']}")
+
+    def post_digest(self, payload: dict, channel: str = "job-posting"):
+        if self.client is None:
+            return None
+
+        title = payload.get("title") or "Untitled opportunity"
+        customer = payload.get("customer") or "Unknown customer"
+        deadline = payload.get("deadline") or "Unknown deadline"
+        source_count = payload.get("source_count", 0)
+        confidence = payload.get("confidence", 0)
+        review_status = payload.get("review_status", "needs_review")
+        cluster_id = payload.get("cluster_id")
+        text = f"KOIS digest: {title}"
+        blocks = [
+            HeaderBlock(text=PlainTextObject(text=f"KOIS: {title}")),
+            SectionBlock(
+                fields=[
+                    MarkdownTextObject(text=f"*Kunde:*\n{customer}"),
+                    MarkdownTextObject(text=f"*Frist:*\n{deadline}"),
+                    MarkdownTextObject(text=f"*Kilder:*\n{source_count}"),
+                    MarkdownTextObject(text=f"*Status:*\n{review_status}"),
+                    MarkdownTextObject(text=f"*Confidence:*\n{confidence:.2f}"),
+                    MarkdownTextObject(text=f"*Cluster ID:*\n{cluster_id}"),
+                ]
+            ),
+        ]
+        try:
+            return self.client.chat_postMessage(channel=channel, text=text, blocks=blocks)
         except SlackApiError as e:
             print(f"Slack API Error: {e.response['error']}")
 

--- a/job_scraper/summarizer.py
+++ b/job_scraper/summarizer.py
@@ -14,16 +14,20 @@ class JobDescriptionSummarizer:
         Use markdown for Slack as the formatting for the summary. Use one * instead of two when doing bold headlines.
     """
 
-    def __init__(self):
+    def __init__(self, optional: bool = False):
         api_key = os.getenv("GEMINI_API_KEY")
 
         if not api_key:
-            print(f"No GEMINI_API_KEY in environment")
-            exit(1)
+            if optional:
+                self.client = None
+                return
+            raise ValueError("No GEMINI_API_KEY in environment")
 
         self.client = genai.Client(api_key=api_key)
 
     def summarize(self, description: str):
+        if self.client is None:
+            return None
         response = self.client.models.generate_content(
             model="gemini-2.0-flash",
             config=types.GenerateContentConfig(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,26 @@
 [project]
 name = "job-scraper"
 version = "0.1.0"
-description = ""
+description = "KOIS Phase 1 foundation and ingestion pipeline"
 authors = ["Daniel Sørenes <daniel@kynd.no>"]
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "google-genai>=1.10.0",
     "playwright>=1.51.0",
+    "psycopg[binary]",
     "pydantic>=2.11.3",
+    "pydantic-settings",
     "python-dotenv>=1.1.0",
+    "sqlalchemy",
     "slack-sdk>=3.35.0",
+    "fastapi",
+    "uvicorn",
+]
+
+[dependency-groups]
+dev = [
+    "pytest",
+    "pytest-asyncio",
+    "ruff",
 ]

--- a/tests/test_baseline_behavior.py
+++ b/tests/test_baseline_behavior.py
@@ -1,0 +1,37 @@
+from job_scraper.models import Job, JobOverview
+from job_scraper.new_job_detector import NewJobPostDetector
+from job_scraper.slack_poster import SlackPoster
+
+
+def _job(uri: str) -> Job:
+    return Job(
+        job_overview=JobOverview(
+            title="Senior Python Developer",
+            company="Acme",
+            description="Description",
+            delivery_date="2026-06-20",
+            job_uri=uri,
+        ),
+        description="Need a senior Python developer",
+        platform="Mercell",
+    )
+
+
+def test_new_job_detector_detects_only_unknown_jobs(tmp_path):
+    detector = NewJobPostDetector(str(tmp_path / "jobs.json"))
+    first = _job("https://example.com/a")
+    second = _job("https://example.com/b")
+    detector.update_known_jobs([first])
+
+    fresh_detector = NewJobPostDetector(str(tmp_path / "jobs.json"))
+    new_jobs = fresh_detector.detect_new_jobs([first, second])
+
+    assert len(new_jobs) == 1
+    assert new_jobs[0].job_id == "https://example.com/b"
+
+
+def test_slack_message_generation_is_stable():
+    poster = SlackPoster(optional=True)
+    text, blocks = poster.create_job_slack_message(_job("https://example.com/a"))
+    assert "Ny utlysning" in text
+    assert blocks[0].text.text == "Senior Python Developer"

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -1,0 +1,79 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from job_scraper.kois.digest import send_digest_items
+from job_scraper.kois.repository import (
+    attach_cluster_source,
+    create_extracted_record,
+    create_or_update_cluster,
+    upsert_raw_source_item,
+)
+from job_scraper.kois.schema import Base, ReviewStatus
+from job_scraper.kois.domain import RawIngestionItem
+from job_scraper.slack_poster import SlackPoster
+
+
+def _session() -> Session:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    return Session(bind=engine, future=True)
+
+
+def test_digest_item_not_resent_when_already_sent():
+    session = _session()
+    raw = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="scraper",
+            source_name="mercell",
+            external_id="id",
+            raw_body="raw-data",
+        ),
+    )
+    record = create_extracted_record(
+        session,
+        {
+            "raw_source_item_id": raw.id,
+            "title": "Assignment",
+            "customer": "Kynd",
+            "broker": "mercell",
+            "source_url": "https://example.com/a",
+            "deadline": "2026-06-30",
+            "description": "desc",
+            "summary": "sum",
+            "extracted_data": {},
+            "extraction_confidence": 0.95,
+        },
+    )
+    cluster = create_or_update_cluster(
+        session=session,
+        cluster_key="https://example.com/a",
+        title="Assignment",
+        customer="Kynd",
+        confidence=0.95,
+        review_status=ReviewStatus.AUTO_ACCEPTED,
+    )
+    attach_cluster_source(session, cluster, record, 0.95, "url")
+    cluster.primary_source_record_id = record.id
+    session.commit()
+
+    slack = SlackPoster(optional=True)
+    first = send_digest_items(
+        session=session,
+        clusters=[cluster],
+        slack=slack,
+        live_posting=False,
+        channel="job-posting",
+    )
+    session.commit()
+    second = send_digest_items(
+        session=session,
+        clusters=[cluster],
+        slack=slack,
+        live_posting=False,
+        channel="job-posting",
+    )
+    session.commit()
+
+    assert len(first) == 1
+    assert len(second) == 0

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -77,3 +77,58 @@ def test_digest_item_not_resent_when_already_sent():
 
     assert len(first) == 1
     assert len(second) == 0
+
+
+def test_digest_not_marked_sent_when_live_post_fails():
+    session = _session()
+    raw = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="scraper",
+            source_name="mercell",
+            external_id="id",
+            raw_body="raw-data",
+        ),
+    )
+    record = create_extracted_record(
+        session,
+        {
+            "raw_source_item_id": raw.id,
+            "title": "Assignment",
+            "customer": "Kynd",
+            "broker": "mercell",
+            "source_url": "https://example.com/a",
+            "deadline": "2026-06-30",
+            "description": "desc",
+            "summary": "sum",
+            "extracted_data": {},
+            "extraction_confidence": 0.95,
+        },
+    )
+    cluster = create_or_update_cluster(
+        session=session,
+        cluster_key="https://example.com/a",
+        title="Assignment",
+        customer="Kynd",
+        confidence=0.95,
+        review_status=ReviewStatus.AUTO_ACCEPTED,
+    )
+    attach_cluster_source(session, cluster, record, 0.95, "url")
+    cluster.primary_source_record_id = record.id
+    session.commit()
+
+    class FailingSlack(SlackPoster):
+        def post_digest(self, payload, channel="job-posting"):
+            return None
+
+    sent = send_digest_items(
+        session=session,
+        clusters=[cluster],
+        slack=FailingSlack(optional=True),
+        live_posting=True,
+        channel="job-posting",
+    )
+    session.commit()
+
+    assert sent == []
+    assert cluster.digest_items[0].sent_at is None

--- a/tests/test_imap_adapter.py
+++ b/tests/test_imap_adapter.py
@@ -1,0 +1,53 @@
+from job_scraper.kois.config import KOISSettings
+from job_scraper.kois.ingestion.imap_adapter import fetch_imap_items
+
+
+class FakeImapConnection:
+    def __init__(self):
+        self.logged_in = False
+
+    def login(self, _username, _password):
+        self.logged_in = True
+        return "OK", [b"Logged in"]
+
+    def select(self, _mailbox):
+        return "OK", [b"1"]
+
+    def uid(self, command, *_args):
+        if command == "SEARCH":
+            return "OK", [b"1"]
+        if command == "FETCH":
+            message = (
+                b"From: sender@example.com\r\n"
+                b"To: oppdrag@kynd.no\r\n"
+                b"Subject: Oppdrag: Data Engineer\r\n"
+                b"Message-ID: <msg1@example.com>\r\n"
+                b"Date: Fri, 05 Jun 2026 12:00:00 +0000\r\n"
+                b"\r\n"
+                b"Frist: 2026-06-30\r\n"
+                b"Se mer: https://example.com/job/1\r\n"
+            )
+            return "OK", [(b"1 (RFC822 {200}", message)]
+        return "NO", []
+
+    def logout(self):
+        return "BYE", [b"logout"]
+
+
+def test_fetch_imap_items_maps_email_to_raw_item(monkeypatch):
+    monkeypatch.setattr(
+        "job_scraper.kois.ingestion.imap_adapter.imaplib.IMAP4_SSL",
+        lambda _host, _port: FakeImapConnection(),
+    )
+    settings = KOISSettings(
+        imap_host="imap.example.com",
+        imap_username="user",
+        imap_password="pass",
+        imap_source_name="oppdrag@kynd.no",
+    )
+
+    items = fetch_imap_items(settings)
+    assert len(items) == 1
+    assert items[0].source_type == "email"
+    assert items[0].external_id == "<msg1@example.com>"
+    assert "https://example.com/job/1" in items[0].raw_body

--- a/tests/test_kois_bug1_primary_source.py
+++ b/tests/test_kois_bug1_primary_source.py
@@ -1,0 +1,71 @@
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from job_scraper.kois.clustering import cluster_records
+from job_scraper.kois.domain import RawIngestionItem
+from job_scraper.kois.repository import create_extracted_record, upsert_raw_source_item
+from job_scraper.kois.schema import Base, OpportunityCluster
+
+
+def _session() -> Session:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    return Session(bind=engine, future=True)
+
+
+def test_primary_source_prefers_scraper_over_email_when_broker_label_is_not_literal():
+    session = _session()
+    raw_email = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="email",
+            source_name="oppdrag@kynd.no",
+            external_id="mail-1",
+            raw_body="email-content",
+        ),
+    )
+    raw_scraper = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="scraper",
+            source_name="mercell",
+            external_id="scraper-1",
+            raw_body="scraper-content",
+        ),
+    )
+    email_record = create_extracted_record(
+        session,
+        {
+            "raw_source_item_id": raw_email.id,
+            "title": "Data Engineer",
+            "customer": "Kynd",
+            "broker": "sender@example.com",
+            "source_url": "https://example.com/a",
+            "deadline": "2026-06-30",
+            "description": "desc",
+            "summary": "sum",
+            "extracted_data": {"source_type": "email"},
+            "extraction_confidence": 0.8,
+        },
+    )
+    scraper_record = create_extracted_record(
+        session,
+        {
+            "raw_source_item_id": raw_scraper.id,
+            "title": "Data Engineer",
+            "customer": "Kynd",
+            "broker": "Mercell",
+            "source_url": "https://example.com/a",
+            "deadline": "2026-06-30",
+            "description": "desc",
+            "summary": "sum",
+            "extracted_data": {"source_type": "scraper", "platform": "Mercell"},
+            "extraction_confidence": 0.9,
+        },
+    )
+
+    cluster_records(session, [email_record, scraper_record])
+    session.commit()
+
+    cluster = session.execute(select(OpportunityCluster)).scalar_one()
+    assert cluster.primary_source_record_id == scraper_record.id

--- a/tests/test_kois_bug2_digest_pending_cleanup.py
+++ b/tests/test_kois_bug2_digest_pending_cleanup.py
@@ -1,0 +1,51 @@
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from job_scraper.kois.digest import send_digest_items
+from job_scraper.kois.repository import create_digest_item, create_or_update_cluster
+from job_scraper.kois.schema import Base, DigestItem, ReviewStatus
+from job_scraper.slack_poster import SlackPoster
+
+
+def _session() -> Session:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    return Session(bind=engine, future=True)
+
+
+def test_ignored_cluster_clears_unsent_digest_items():
+    session = _session()
+    cluster = create_or_update_cluster(
+        session=session,
+        cluster_key="cluster-ignored-pending",
+        title="Ignore this",
+        customer="Kynd",
+        confidence=0.9,
+        review_status=ReviewStatus.IGNORED,
+    )
+    create_digest_item(
+        session=session,
+        cluster=cluster,
+        status=ReviewStatus.IGNORED,
+        payload={"cluster_id": cluster.id, "review_status": ReviewStatus.IGNORED.value},
+    )
+    session.commit()
+
+    sent = send_digest_items(
+        session=session,
+        clusters=[cluster],
+        slack=SlackPoster(optional=True),
+        live_posting=False,
+        channel="job-posting",
+    )
+    session.commit()
+
+    unsent = session.execute(
+        select(DigestItem).where(
+            DigestItem.opportunity_cluster_id == cluster.id,
+            DigestItem.sent_at.is_(None),
+        )
+    ).scalars().all()
+
+    assert sent == []
+    assert unsent == []

--- a/tests/test_kois_bug3_content_hash_collision.py
+++ b/tests/test_kois_bug3_content_hash_collision.py
@@ -1,0 +1,50 @@
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from job_scraper.kois.domain import RawIngestionItem
+from job_scraper.kois.repository import upsert_raw_source_item
+from job_scraper.kois.schema import Base, RawSourceItem
+
+
+def _session() -> Session:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    return Session(bind=engine, future=True)
+
+
+def test_raw_source_upsert_avoids_hash_collision_when_external_content_changes():
+    session = _session()
+    existing_by_external = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="email",
+            source_name="oppdrag@kynd.no",
+            external_id="<message-1@example.com>",
+            raw_body="body-one",
+        ),
+    )
+    existing_by_hash = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="email",
+            source_name="oppdrag@kynd.no",
+            external_id="<message-2@example.com>",
+            raw_body="body-two",
+        ),
+    )
+    collided = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="email",
+            source_name="oppdrag@kynd.no",
+            external_id="<message-1@example.com>",
+            raw_body="body-two",
+            metadata={"subject": "latest"},
+        ),
+    )
+    session.commit()
+
+    all_rows = session.execute(select(RawSourceItem)).scalars().all()
+    assert collided.id == existing_by_hash.id
+    assert existing_by_external.id != existing_by_hash.id
+    assert len(all_rows) == 2

--- a/tests/test_kois_bug3_content_hash_collision.py
+++ b/tests/test_kois_bug3_content_hash_collision.py
@@ -12,7 +12,7 @@ def _session() -> Session:
     return Session(bind=engine, future=True)
 
 
-def test_raw_source_upsert_avoids_hash_collision_when_external_content_changes():
+def test_raw_source_upsert_updates_external_id_row_when_body_matches_existing_hash():
     session = _session()
     existing_by_external = upsert_raw_source_item(
         session,
@@ -30,6 +30,7 @@ def test_raw_source_upsert_avoids_hash_collision_when_external_content_changes()
             source_name="oppdrag@kynd.no",
             external_id="<message-2@example.com>",
             raw_body="body-two",
+            metadata={"subject": "message-two"},
         ),
     )
     collided = upsert_raw_source_item(
@@ -43,8 +44,13 @@ def test_raw_source_upsert_avoids_hash_collision_when_external_content_changes()
         ),
     )
     session.commit()
+    session.refresh(existing_by_hash)
 
     all_rows = session.execute(select(RawSourceItem)).scalars().all()
-    assert collided.id == existing_by_hash.id
-    assert existing_by_external.id != existing_by_hash.id
+    assert collided.id == existing_by_external.id
+    assert collided.external_id == "<message-1@example.com>"
+    assert collided.raw_body == "body-two"
+    assert collided.metadata_json == {"subject": "latest"}
+    assert existing_by_hash.raw_body == "body-two"
+    assert existing_by_hash.metadata_json == {"subject": "message-two"}
     assert len(all_rows) == 2

--- a/tests/test_kois_services.py
+++ b/tests/test_kois_services.py
@@ -311,6 +311,39 @@ def test_cluster_to_payload_uses_primary_source_deadline():
     assert payload.deadline == "2026-07-01"
 
 
+def test_raw_source_upsert_creates_separate_row_for_duplicate_body():
+    session = _session()
+    shared_body = "identical-body-content"
+    first = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="email",
+            source_name="oppdrag@kynd.no",
+            external_id="<message-1@example.com>",
+            raw_body=shared_body,
+            metadata={"subject": "first"},
+        ),
+    )
+    second = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="email",
+            source_name="oppdrag@kynd.no",
+            external_id="<message-2@example.com>",
+            raw_body=shared_body,
+            metadata={"subject": "second"},
+        ),
+    )
+    session.commit()
+
+    all_rows = session.execute(select(RawSourceItem)).scalars().all()
+    assert first.id != second.id
+    assert first.content_hash == second.content_hash
+    assert first.metadata_json == {"subject": "first"}
+    assert second.metadata_json == {"subject": "second"}
+    assert len(all_rows) == 2
+
+
 def test_raw_source_upsert_reuses_external_id_when_body_changes():
     session = _session()
     first = upsert_raw_source_item(

--- a/tests/test_kois_services.py
+++ b/tests/test_kois_services.py
@@ -20,6 +20,7 @@ from job_scraper.kois.schema import (
     DigestItem,
     ExtractedRecord,
     OpportunityCluster,
+    RawSourceItem,
     ReviewStatus,
     SourceComparison,
 )
@@ -298,4 +299,31 @@ def test_cluster_to_payload_uses_primary_source_deadline():
 
     payload = cluster_to_payload(cluster)
     assert payload.deadline == "2026-07-01"
+
+
+def test_raw_source_upsert_reuses_external_id_when_body_changes():
+    session = _session()
+    first = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="email",
+            source_name="oppdrag@kynd.no",
+            external_id="<message-1@example.com>",
+            raw_body="original-body",
+        ),
+    )
+    second = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="email",
+            source_name="oppdrag@kynd.no",
+            external_id="<message-1@example.com>",
+            raw_body="updated-body",
+        ),
+    )
+    session.commit()
+
+    all_rows = session.execute(select(RawSourceItem)).scalars().all()
+    assert second.id == first.id
+    assert len(all_rows) == 1
 

--- a/tests/test_kois_services.py
+++ b/tests/test_kois_services.py
@@ -454,3 +454,31 @@ def test_orchestrator_retries_pending_digests_not_touched_this_run(monkeypatch):
     assert digest_item.sent_at is not None
 
 
+def test_scraper_fallback_external_id_avoids_title_collisions_without_uri():
+    from job_scraper.kois.ingestion.scraper_adapter import jobs_to_raw_items
+
+    first_job = Job(
+        job_overview=JobOverview(
+            title="Backend Developer",
+            company="Kynd A",
+            delivery_date="2026-06-30",
+            job_uri=None,
+        ),
+        description="First listing",
+        platform="Mercell",
+    )
+    second_job = Job(
+        job_overview=JobOverview(
+            title="Backend Developer",
+            company="Kynd B",
+            delivery_date="2026-07-30",
+            job_uri=None,
+        ),
+        description="Second listing",
+        platform="Mercell",
+    )
+
+    raw_items = jobs_to_raw_items([first_job, second_job])
+    assert raw_items[0].external_id != raw_items[1].external_id
+
+

--- a/tests/test_kois_services.py
+++ b/tests/test_kois_services.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 
 from job_scraper.kois.clustering import cluster_records
 from job_scraper.kois.domain import RawIngestionItem
-from job_scraper.kois.extraction import RecordExtractor
+from job_scraper.kois.extraction import RecordExtractor, make_cluster_key
 from job_scraper.kois.repository import (
     create_extracted_record,
     create_or_update_cluster,
@@ -196,4 +196,10 @@ def test_refresh_comparisons_is_idempotent():
 
     assert len(first_pass) == len(second_pass)
     assert {comparison.field_name for comparison in second_pass} == {"title", "broker"}
+
+
+def test_make_cluster_key_normalizes_trailing_slash_urls():
+    with_slash = make_cluster_key({"source_url": "https://example.com/jobs/1/"})
+    without_slash = make_cluster_key({"source_url": "https://example.com/jobs/1"})
+    assert with_slash == without_slash
 

--- a/tests/test_kois_services.py
+++ b/tests/test_kois_services.py
@@ -312,6 +312,7 @@ def test_raw_source_upsert_reuses_external_id_when_body_changes():
             raw_body="original-body",
         ),
     )
+    first_hash = first.content_hash
     second = upsert_raw_source_item(
         session,
         RawIngestionItem(
@@ -326,4 +327,62 @@ def test_raw_source_upsert_reuses_external_id_when_body_changes():
     all_rows = session.execute(select(RawSourceItem)).scalars().all()
     assert second.id == first.id
     assert len(all_rows) == 1
+    assert second.raw_body == "updated-body"
+    assert second.content_hash != first_hash
+
+
+def test_orchestrator_reextracts_when_raw_body_changes(monkeypatch):
+    from job_scraper.kois.orchestrator import run_kois_pipeline
+
+    session = _session()
+    monkeypatch.setattr(
+        "job_scraper.kois.orchestrator.fetch_imap_items",
+        lambda settings: [],
+    )
+    monkeypatch.setattr(
+        "job_scraper.kois.orchestrator.get_settings",
+        lambda: type(
+            "Settings",
+            (),
+            {
+                "gemini_api_key": None,
+                "run_live_slack": False,
+                "slack_channel": "job-posting",
+            },
+        )(),
+    )
+
+    first_job = Job(
+        job_overview=JobOverview(
+            title="Data Engineer",
+            company="Kynd",
+            delivery_date="2026-06-30",
+            job_uri="https://example.com/jobs/1",
+        ),
+        description="First description",
+        platform="Mercell",
+    )
+    second_job = Job(
+        job_overview=JobOverview(
+            title="Data Engineer",
+            company="Kynd",
+            delivery_date="2026-07-15",
+            job_uri="https://example.com/jobs/1",
+        ),
+        description="Updated description",
+        platform="Mercell",
+    )
+
+    run_kois_pipeline(session=session, scraped_jobs=[first_job])
+    run_kois_pipeline(session=session, scraped_jobs=[second_job])
+
+    raw_rows = session.execute(select(RawSourceItem)).scalars().all()
+    extracted_rows = session.execute(select(ExtractedRecord)).scalars().all()
+
+    assert len(raw_rows) == 1
+    assert len(extracted_rows) == 2
+    latest_record = extracted_rows[-1]
+    assert latest_record.description == "Updated description"
+    assert latest_record.deadline == "2026-07-15"
+
 

--- a/tests/test_kois_services.py
+++ b/tests/test_kois_services.py
@@ -5,14 +5,17 @@ from job_scraper.kois.clustering import cluster_records
 from job_scraper.kois.domain import RawIngestionItem
 from job_scraper.kois.extraction import RecordExtractor, make_cluster_key
 from job_scraper.kois.repository import (
+    create_digest_item,
     create_extracted_record,
     create_or_update_cluster,
     get_extracted_record_for_raw_source,
+    mark_digest_sent,
     upsert_raw_source_item,
 )
 from job_scraper.kois.schema import (
     Base,
     ClusterSource,
+    DigestItem,
     ExtractedRecord,
     OpportunityCluster,
     ReviewStatus,
@@ -202,4 +205,37 @@ def test_make_cluster_key_normalizes_trailing_slash_urls():
     with_slash = make_cluster_key({"source_url": "https://example.com/jobs/1/"})
     without_slash = make_cluster_key({"source_url": "https://example.com/jobs/1"})
     assert with_slash == without_slash
+
+
+def test_create_digest_item_prevents_second_send_after_status_change():
+    session = _session()
+    cluster = create_or_update_cluster(
+        session=session,
+        cluster_key="cluster-a",
+        title="Assignment",
+        customer="Kynd",
+        confidence=0.8,
+        review_status=ReviewStatus.NEEDS_REVIEW,
+    )
+    first = create_digest_item(
+        session=session,
+        cluster=cluster,
+        status=ReviewStatus.NEEDS_REVIEW,
+        payload={"cluster_id": cluster.id, "review_status": ReviewStatus.NEEDS_REVIEW.value},
+    )
+    mark_digest_sent(session, first, slack_ts="123.45")
+    session.commit()
+
+    second = create_digest_item(
+        session=session,
+        cluster=cluster,
+        status=ReviewStatus.AUTO_ACCEPTED,
+        payload={"cluster_id": cluster.id, "review_status": ReviewStatus.AUTO_ACCEPTED.value},
+    )
+    session.commit()
+
+    digest_items = session.execute(select(DigestItem)).scalars().all()
+    assert second.id == first.id
+    assert second.sent_at is not None
+    assert len(digest_items) == 1
 

--- a/tests/test_kois_services.py
+++ b/tests/test_kois_services.py
@@ -1,0 +1,68 @@
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from job_scraper.kois.clustering import cluster_records
+from job_scraper.kois.domain import RawIngestionItem
+from job_scraper.kois.extraction import RecordExtractor
+from job_scraper.kois.repository import create_extracted_record, upsert_raw_source_item
+from job_scraper.kois.schema import Base, OpportunityCluster, ReviewStatus
+from job_scraper.models import Job, JobOverview
+
+
+def _session() -> Session:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    return Session(bind=engine, future=True)
+
+
+def test_raw_source_upsert_is_idempotent():
+    session = _session()
+    item = RawIngestionItem(
+        source_type="scraper",
+        source_name="mercell",
+        external_id="id-1",
+        raw_body="same-content",
+        metadata={"title": "A"},
+    )
+    first = upsert_raw_source_item(session, item)
+    second = upsert_raw_source_item(session, item)
+    session.commit()
+
+    assert first.id == second.id
+
+
+def test_extraction_and_clustering_creates_review_status():
+    session = _session()
+    extractor = RecordExtractor(summarizer=None)
+    job = Job(
+        job_overview=JobOverview(
+            title="Data Engineer",
+            company="Kynd",
+            delivery_date="2026-06-30",
+            job_uri="https://example.com/jobs/1",
+        ),
+        description="Build data pipelines",
+        platform="Mercell",
+    )
+    raw = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="scraper",
+            source_name="mercell",
+            external_id="https://example.com/jobs/1",
+            raw_body=job.model_dump_json(),
+            metadata={"platform": "Mercell"},
+        ),
+    )
+    payload = extractor.extract(raw)
+    record = create_extracted_record(session, payload)
+    clusters = cluster_records(session, [record])
+    session.commit()
+
+    stored_cluster = session.execute(select(OpportunityCluster)).scalar_one()
+    assert len(clusters) == 1
+    assert stored_cluster.review_status in (
+        ReviewStatus.AUTO_ACCEPTED,
+        ReviewStatus.NEEDS_REVIEW,
+    )
+    assert stored_cluster.primary_source_record_id == record.id

--- a/tests/test_kois_services.py
+++ b/tests/test_kois_services.py
@@ -10,7 +10,14 @@ from job_scraper.kois.repository import (
     get_extracted_record_for_raw_source,
     upsert_raw_source_item,
 )
-from job_scraper.kois.schema import Base, ClusterSource, ExtractedRecord, OpportunityCluster, ReviewStatus
+from job_scraper.kois.schema import (
+    Base,
+    ClusterSource,
+    ExtractedRecord,
+    OpportunityCluster,
+    ReviewStatus,
+    SourceComparison,
+)
 from job_scraper.models import Job, JobOverview
 
 
@@ -138,3 +145,55 @@ def test_create_or_update_cluster_preserves_reviewer_status():
     assert updated.id == cluster.id
     assert updated.review_status == ReviewStatus.IGNORED
     assert updated.confidence == 0.95
+
+
+def test_refresh_comparisons_is_idempotent():
+    session = _session()
+    raw = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="scraper",
+            source_name="mercell",
+            external_id="id-1",
+            raw_body="raw-1",
+        ),
+    )
+    record_a = create_extracted_record(
+        session,
+        {
+            "raw_source_item_id": raw.id,
+            "title": "Assignment A",
+            "customer": "Kynd",
+            "broker": "mercell",
+            "source_url": "https://example.com/a",
+            "deadline": "2026-06-30",
+            "description": "desc",
+            "summary": "sum",
+            "extracted_data": {},
+            "extraction_confidence": 0.95,
+        },
+    )
+    record_b = create_extracted_record(
+        session,
+        {
+            "raw_source_item_id": raw.id,
+            "title": "Assignment B",
+            "customer": "Kynd",
+            "broker": "email",
+            "source_url": "https://example.com/a",
+            "deadline": "2026-06-30",
+            "description": "desc",
+            "summary": "sum",
+            "extracted_data": {},
+            "extraction_confidence": 0.95,
+        },
+    )
+    cluster_records(session, [record_a, record_b])
+    first_pass = session.execute(select(SourceComparison)).scalars().all()
+    cluster_records(session, [record_a, record_b])
+    second_pass = session.execute(select(SourceComparison)).scalars().all()
+    session.commit()
+
+    assert len(first_pass) == len(second_pass)
+    assert {comparison.field_name for comparison in second_pass} == {"title", "broker"}
+

--- a/tests/test_kois_services.py
+++ b/tests/test_kois_services.py
@@ -1,7 +1,7 @@
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session
 
-from job_scraper.kois.clustering import cluster_records
+from job_scraper.kois.clustering import _similarity, cluster_records
 from job_scraper.kois.digest import cluster_to_payload
 from job_scraper.kois.domain import RawIngestionItem
 from job_scraper.kois.extraction import RecordExtractor, make_cluster_key
@@ -528,6 +528,72 @@ def test_orchestrator_retries_pending_digests_not_touched_this_run(monkeypatch):
     assert result["clusters"] == 0
     assert result["digests"] == 1
     assert digest_item.sent_at is not None
+
+
+def test_similarity_does_not_credit_deadline_without_cluster_match():
+    session = _session()
+    raw_a = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="scraper",
+            source_name="mercell",
+            external_id="deadline-a",
+            raw_body="raw-a",
+        ),
+    )
+    raw_b = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="email",
+            source_name="oppdrag@kynd.no",
+            external_id="deadline-b",
+            raw_body="raw-b",
+        ),
+    )
+    first_record = create_extracted_record(
+        session,
+        {
+            "raw_source_item_id": raw_a.id,
+            "title": "Assignment",
+            "customer": "Kynd",
+            "broker": "mercell",
+            "source_url": "https://example.com/a",
+            "deadline": "2026-06-30",
+            "description": "desc",
+            "summary": "sum",
+            "extracted_data": {},
+            "extraction_confidence": 0.95,
+        },
+    )
+    second_record = create_extracted_record(
+        session,
+        {
+            "raw_source_item_id": raw_b.id,
+            "title": "Assignment",
+            "customer": "Kynd",
+            "broker": "email",
+            "source_url": "https://example.com/a",
+            "deadline": "2026-07-15",
+            "description": "desc",
+            "summary": "sum",
+            "extracted_data": {},
+            "extraction_confidence": 0.95,
+        },
+    )
+    cluster = create_or_update_cluster(
+        session=session,
+        cluster_key="https://example.com/a",
+        title="Assignment",
+        customer="Kynd",
+        confidence=0.95,
+        review_status=ReviewStatus.AUTO_ACCEPTED,
+    )
+    attach_cluster_source(session, cluster, first_record, confidence=0.9, rationale="url,title,customer,deadline")
+    session.commit()
+
+    score, rationale = _similarity(session, second_record, cluster)
+    assert "deadline" not in rationale.split(",")
+    assert score < 1.0
 
 
 def test_orchestrator_detaches_stale_cluster_source_when_reextraction_fails(monkeypatch):

--- a/tests/test_kois_services.py
+++ b/tests/test_kois_services.py
@@ -11,6 +11,7 @@ from job_scraper.kois.repository import (
     create_extracted_record,
     create_or_update_cluster,
     get_extracted_record_for_raw_source,
+    list_clusters_with_unsent_digests,
     mark_digest_sent,
     upsert_raw_source_item,
 )
@@ -384,5 +385,72 @@ def test_orchestrator_reextracts_when_raw_body_changes(monkeypatch):
     latest_record = extracted_rows[-1]
     assert latest_record.description == "Updated description"
     assert latest_record.deadline == "2026-07-15"
+
+
+def test_list_clusters_with_unsent_digests_returns_retry_candidates():
+    session = _session()
+    cluster = create_or_update_cluster(
+        session=session,
+        cluster_key="cluster-retry",
+        title="Retry me",
+        customer="Kynd",
+        confidence=0.9,
+        review_status=ReviewStatus.AUTO_ACCEPTED,
+    )
+    create_digest_item(
+        session=session,
+        cluster=cluster,
+        status=ReviewStatus.AUTO_ACCEPTED,
+        payload={"cluster_id": cluster.id},
+    )
+    session.commit()
+
+    pending_clusters = list_clusters_with_unsent_digests(session)
+    assert [item.id for item in pending_clusters] == [cluster.id]
+
+
+def test_orchestrator_retries_pending_digests_not_touched_this_run(monkeypatch):
+    from job_scraper.kois.orchestrator import run_kois_pipeline
+
+    session = _session()
+    cluster = create_or_update_cluster(
+        session=session,
+        cluster_key="cluster-pending-retry",
+        title="Pending digest",
+        customer="Kynd",
+        confidence=0.9,
+        review_status=ReviewStatus.AUTO_ACCEPTED,
+    )
+    create_digest_item(
+        session=session,
+        cluster=cluster,
+        status=ReviewStatus.AUTO_ACCEPTED,
+        payload={"cluster_id": cluster.id, "review_status": ReviewStatus.AUTO_ACCEPTED.value},
+    )
+    session.commit()
+
+    monkeypatch.setattr(
+        "job_scraper.kois.orchestrator.fetch_imap_items",
+        lambda settings: [],
+    )
+    monkeypatch.setattr(
+        "job_scraper.kois.orchestrator.get_settings",
+        lambda: type(
+            "Settings",
+            (),
+            {
+                "gemini_api_key": None,
+                "run_live_slack": False,
+                "slack_channel": "job-posting",
+            },
+        )(),
+    )
+
+    result = run_kois_pipeline(session=session, scraped_jobs=[])
+    digest_item = session.execute(select(DigestItem)).scalar_one()
+
+    assert result["clusters"] == 0
+    assert result["digests"] == 1
+    assert digest_item.sent_at is not None
 
 

--- a/tests/test_kois_services.py
+++ b/tests/test_kois_services.py
@@ -2,9 +2,11 @@ from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session
 
 from job_scraper.kois.clustering import cluster_records
+from job_scraper.kois.digest import cluster_to_payload
 from job_scraper.kois.domain import RawIngestionItem
 from job_scraper.kois.extraction import RecordExtractor, make_cluster_key
 from job_scraper.kois.repository import (
+    attach_cluster_source,
     create_digest_item,
     create_extracted_record,
     create_or_update_cluster,
@@ -238,4 +240,62 @@ def test_create_digest_item_prevents_second_send_after_status_change():
     assert second.id == first.id
     assert second.sent_at is not None
     assert len(digest_items) == 1
+
+
+def test_cluster_to_payload_uses_primary_source_deadline():
+    session = _session()
+    raw = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="scraper",
+            source_name="mercell",
+            external_id="id-deadline",
+            raw_body="raw-deadline",
+        ),
+    )
+    primary = create_extracted_record(
+        session,
+        {
+            "raw_source_item_id": raw.id,
+            "title": "Assignment",
+            "customer": "Kynd",
+            "broker": "mercell",
+            "source_url": "https://example.com/a",
+            "deadline": "2026-07-01",
+            "description": "desc",
+            "summary": "sum",
+            "extracted_data": {},
+            "extraction_confidence": 0.9,
+        },
+    )
+    secondary = create_extracted_record(
+        session,
+        {
+            "raw_source_item_id": raw.id,
+            "title": "Assignment",
+            "customer": "Kynd",
+            "broker": "email",
+            "source_url": "https://example.com/a",
+            "deadline": "2026-08-01",
+            "description": "desc",
+            "summary": "sum",
+            "extracted_data": {},
+            "extraction_confidence": 0.8,
+        },
+    )
+    cluster = create_or_update_cluster(
+        session=session,
+        cluster_key="cluster-deadline",
+        title="Assignment",
+        customer="Kynd",
+        confidence=0.9,
+        review_status=ReviewStatus.AUTO_ACCEPTED,
+    )
+    attach_cluster_source(session, cluster, secondary, confidence=0.8, rationale="email")
+    attach_cluster_source(session, cluster, primary, confidence=0.9, rationale="broker")
+    cluster.primary_source_record_id = primary.id
+    session.commit()
+
+    payload = cluster_to_payload(cluster)
+    assert payload.deadline == "2026-07-01"
 

--- a/tests/test_kois_services.py
+++ b/tests/test_kois_services.py
@@ -530,6 +530,71 @@ def test_orchestrator_retries_pending_digests_not_touched_this_run(monkeypatch):
     assert digest_item.sent_at is not None
 
 
+def test_orchestrator_detaches_stale_cluster_source_when_reextraction_fails(monkeypatch):
+    from job_scraper.kois.orchestrator import run_kois_pipeline
+
+    session = _session()
+    job = Job(
+        job_overview=JobOverview(
+            title="Data Engineer",
+            company="Kynd",
+            delivery_date="2026-06-30",
+            job_uri="https://example.com/jobs/1",
+        ),
+        description="Original description",
+        platform="Mercell",
+    )
+    monkeypatch.setattr(
+        "job_scraper.kois.orchestrator.fetch_imap_items",
+        lambda settings: [],
+    )
+    monkeypatch.setattr(
+        "job_scraper.kois.orchestrator.get_settings",
+        lambda: type(
+            "Settings",
+            (),
+            {
+                "gemini_api_key": None,
+                "run_live_slack": False,
+                "slack_channel": "job-posting",
+            },
+        )(),
+    )
+
+    run_kois_pipeline(session=session, scraped_jobs=[job])
+
+    class BrokenExtractor:
+        def extract(self, raw_source):
+            raise ValueError("extraction failed")
+
+    monkeypatch.setattr(
+        "job_scraper.kois.orchestrator.RecordExtractor",
+        lambda summarizer=None: BrokenExtractor(),
+    )
+
+    updated_job = Job(
+        job_overview=JobOverview(
+            title="Data Engineer",
+            company="Kynd",
+            delivery_date="2026-07-15",
+            job_uri="https://example.com/jobs/1",
+        ),
+        description="Broken body",
+        platform="Mercell",
+    )
+    run_kois_pipeline(session=session, scraped_jobs=[updated_job])
+
+    raw_item = session.execute(select(RawSourceItem)).scalar_one()
+    cluster = session.execute(select(OpportunityCluster)).scalar_one()
+    cluster_sources = session.execute(select(ClusterSource)).scalars().all()
+    extracted_rows = session.execute(select(ExtractedRecord)).scalars().all()
+
+    assert raw_item.extraction_error == "extraction failed"
+    assert len(extracted_rows) == 1
+    assert cluster_sources == []
+    assert cluster.primary_source_record_id is None
+
+
 def test_scraper_fallback_external_id_avoids_title_collisions_without_uri():
     from job_scraper.kois.ingestion.scraper_adapter import jobs_to_raw_items
 

--- a/tests/test_kois_services.py
+++ b/tests/test_kois_services.py
@@ -156,7 +156,7 @@ def test_create_or_update_cluster_preserves_reviewer_status():
 
 def test_refresh_comparisons_is_idempotent():
     session = _session()
-    raw = upsert_raw_source_item(
+    raw_a = upsert_raw_source_item(
         session,
         RawIngestionItem(
             source_type="scraper",
@@ -165,10 +165,19 @@ def test_refresh_comparisons_is_idempotent():
             raw_body="raw-1",
         ),
     )
+    raw_b = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="email",
+            source_name="oppdrag@kynd.no",
+            external_id="id-2",
+            raw_body="raw-2",
+        ),
+    )
     record_a = create_extracted_record(
         session,
         {
-            "raw_source_item_id": raw.id,
+            "raw_source_item_id": raw_a.id,
             "title": "Assignment A",
             "customer": "Kynd",
             "broker": "mercell",
@@ -183,7 +192,7 @@ def test_refresh_comparisons_is_idempotent():
     record_b = create_extracted_record(
         session,
         {
-            "raw_source_item_id": raw.id,
+            "raw_source_item_id": raw_b.id,
             "title": "Assignment B",
             "customer": "Kynd",
             "broker": "email",
@@ -379,12 +388,21 @@ def test_orchestrator_reextracts_when_raw_body_changes(monkeypatch):
 
     raw_rows = session.execute(select(RawSourceItem)).scalars().all()
     extracted_rows = session.execute(select(ExtractedRecord)).scalars().all()
+    cluster = session.execute(select(OpportunityCluster)).scalar_one()
+    cluster_sources = session.execute(select(ClusterSource)).scalars().all()
+    comparisons = session.execute(select(SourceComparison)).scalars().all()
 
     assert len(raw_rows) == 1
     assert len(extracted_rows) == 2
     latest_record = extracted_rows[-1]
     assert latest_record.description == "Updated description"
     assert latest_record.deadline == "2026-07-15"
+    assert len(cluster_sources) == 1
+    assert cluster_sources[0].extracted_record_id == latest_record.id
+    assert cluster.primary_source_record_id == latest_record.id
+    assert cluster_to_payload(cluster).source_count == 1
+    assert cluster_to_payload(cluster).deadline == "2026-07-15"
+    assert comparisons == []
 
 
 def test_list_clusters_with_unsent_digests_returns_retry_candidates():
@@ -421,6 +439,31 @@ def test_orchestrator_retries_pending_digests_not_touched_this_run(monkeypatch):
         confidence=0.9,
         review_status=ReviewStatus.AUTO_ACCEPTED,
     )
+    raw = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="scraper",
+            source_name="mercell",
+            external_id="pending-source",
+            raw_body="pending raw body",
+        ),
+    )
+    record = create_extracted_record(
+        session,
+        {
+            "raw_source_item_id": raw.id,
+            "title": "Pending digest",
+            "customer": "Kynd",
+            "broker": "mercell",
+            "source_url": "https://example.com/pending",
+            "deadline": "2026-06-30",
+            "description": "desc",
+            "summary": "sum",
+            "extracted_data": {},
+            "extraction_confidence": 0.95,
+        },
+    )
+    attach_cluster_source(session, cluster, record, confidence=0.95, rationale="url")
     create_digest_item(
         session=session,
         cluster=cluster,

--- a/tests/test_kois_services.py
+++ b/tests/test_kois_services.py
@@ -6,6 +6,7 @@ from job_scraper.kois.domain import RawIngestionItem
 from job_scraper.kois.extraction import RecordExtractor
 from job_scraper.kois.repository import (
     create_extracted_record,
+    create_or_update_cluster,
     get_extracted_record_for_raw_source,
     upsert_raw_source_item,
 )
@@ -110,3 +111,30 @@ def test_extracted_record_is_reused_for_existing_raw_source():
     assert session.execute(select(ExtractedRecord)).scalars().all() == [first_record]
     assert len(session.execute(select(ClusterSource)).scalars().all()) == 1
     assert clusters_first[0].id == clusters_second[0].id
+
+
+def test_create_or_update_cluster_preserves_reviewer_status():
+    session = _session()
+    cluster = create_or_update_cluster(
+        session=session,
+        cluster_key="manual-review",
+        title="Assignment",
+        customer="Kynd",
+        confidence=0.7,
+        review_status=ReviewStatus.IGNORED,
+    )
+    session.commit()
+
+    updated = create_or_update_cluster(
+        session=session,
+        cluster_key="manual-review",
+        title="Assignment",
+        customer="Kynd",
+        confidence=0.95,
+        review_status=ReviewStatus.AUTO_ACCEPTED,
+    )
+    session.commit()
+
+    assert updated.id == cluster.id
+    assert updated.review_status == ReviewStatus.IGNORED
+    assert updated.confidence == 0.95

--- a/tests/test_kois_services.py
+++ b/tests/test_kois_services.py
@@ -4,8 +4,12 @@ from sqlalchemy.orm import Session
 from job_scraper.kois.clustering import cluster_records
 from job_scraper.kois.domain import RawIngestionItem
 from job_scraper.kois.extraction import RecordExtractor
-from job_scraper.kois.repository import create_extracted_record, upsert_raw_source_item
-from job_scraper.kois.schema import Base, OpportunityCluster, ReviewStatus
+from job_scraper.kois.repository import (
+    create_extracted_record,
+    get_extracted_record_for_raw_source,
+    upsert_raw_source_item,
+)
+from job_scraper.kois.schema import Base, ClusterSource, ExtractedRecord, OpportunityCluster, ReviewStatus
 from job_scraper.models import Job, JobOverview
 
 
@@ -66,3 +70,43 @@ def test_extraction_and_clustering_creates_review_status():
         ReviewStatus.NEEDS_REVIEW,
     )
     assert stored_cluster.primary_source_record_id == record.id
+
+
+def test_extracted_record_is_reused_for_existing_raw_source():
+    session = _session()
+    extractor = RecordExtractor(summarizer=None)
+    job = Job(
+        job_overview=JobOverview(
+            title="Data Engineer",
+            company="Kynd",
+            delivery_date="2026-06-30",
+            job_uri="https://example.com/jobs/1",
+        ),
+        description="Build data pipelines",
+        platform="Mercell",
+    )
+    raw = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="scraper",
+            source_name="mercell",
+            external_id="https://example.com/jobs/1",
+            raw_body=job.model_dump_json(),
+            metadata={"platform": "Mercell"},
+        ),
+    )
+    payload = extractor.extract(raw)
+    first_record = create_extracted_record(session, payload)
+    session.commit()
+
+    second_record = get_extracted_record_for_raw_source(session, raw.id)
+    assert second_record is not None
+    assert second_record.id == first_record.id
+
+    clusters_first = cluster_records(session, [first_record])
+    clusters_second = cluster_records(session, [second_record])
+    session.commit()
+
+    assert session.execute(select(ExtractedRecord)).scalars().all() == [first_record]
+    assert len(session.execute(select(ClusterSource)).scalars().all()) == 1
+    assert clusters_first[0].id == clusters_second[0].id


### PR DESCRIPTION
## Summary
- Implement a KOIS Phase 1 Postgres foundation with raw source persistence, extraction records, clustering, review states, and digest-item storage.
- Add scraper and IMAP ingestion adapters, a shared orchestration pipeline, and a minimal FastAPI review/archive surface.
- Refactor runtime flow and Slack integration to produce conservative digest output from persisted cluster state, with tests for baseline behavior, IMAP ingestion, clustering, and digest dedupe.

## Test plan
- [x] `python3 -m ruff check .`
- [x] `python3 -m pytest`
- [ ] Manual dry-run against live Postgres + IMAP credentials in a non-production environment
- [ ] Optional live Slack digest smoke test with `RUN_LIVE_SLACK=true`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large behavioral and architectural shift: production runs now depend on PostgreSQL migrations, IMAP/DB config, and a new Slack digest model instead of jobs.json diffing; misconfiguration or clustering bugs could miss or mis-route opportunities.
> 
> **Overview**
> Replaces the **jobs.json + immediate per-job Slack** flow with **KOIS Phase 1**: a Postgres-backed pipeline that ingests broker scrapes and **IMAP** (`oppdrag@kynd.no`), keeps immutable raw evidence, extracts structured records, **clusters duplicates** (with source comparisons and review status), and emits **conservative Slack digests** from persisted cluster state (`RUN_LIVE_SLACK` gates live posts).
> 
> Adds the `job_scraper.kois` stack (SQLAlchemy schema, migrations, repository, orchestrator, digest/review services), a minimal **FastAPI** review API (`/clusters`, `/review-queue`, status PATCH), and refactors `main` to run migrations then `run_kois_pipeline`. **Slack** and **Gemini** summarization can run in optional mode; digest posting uses `post_digest` instead of posting every new scrape.
> 
> Docs and deps shift to PostgreSQL, FastAPI/uvicorn, pytest/ruff; extensive tests cover clustering, digest dedupe, IMAP adapter, and regression fixes (primary source priority, ignored-cluster digest cleanup, raw-source upsert by external id).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3e3e019e90fbfc8fa5185464d8be27af21c1749. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->