### PR TITLE
feat: implement KOIS Phase 2 market and agreement intelligence

### DIFF
--- a/PID.md
+++ b/PID.md
@@ -50,6 +50,7 @@ KOIS does not own:
 - `PrimarySource`: the preferred source for display and decisioning at a point in time.
 - `SourceComparison`: differences, overlaps, and additions across source records in a cluster.
 - `AgreementSignal`: DPS or frame-agreement information that may not be assignment-related.
+- `AgreementGap`: persisted potential coverage gap where repeated buyer demand appears without matching agreement signals.
 - `ReviewState`: `auto_accepted`, `needs_review`, `manually_merged`, `manually_split`, `ignored`, or `watch_only`.
 - `DigestItem`: generated output for Slack or reports, backed by stored evidence.
 - `ExternalFitAssessment`: later KBS-provided fit assessment for consultants, CVs, references, or bid material.
@@ -81,6 +82,8 @@ Implementation status: in progress. Current implementation uses Postgres-backed 
 Add Doffin and procurement monitoring, agreement-signal handling, buyer and broker analytics, and discovery of DPS or frame agreements Kynd may not have found or applied for.
 
 Success metric: KOIS identifies market patterns and agreement coverage gaps, not only new assignments.
+
+Implementation status: in progress. Current implementation adds procurement feed adapters, canonical source taxonomy for clustering priority, persisted agreement signals and agreement gaps, analytics summary services, and API endpoints for market intelligence and gap triage.
 
 ### Phase 3: Sales Opportunity Filtering
 

--- a/job_scraper/kois/agreement_signals.py
+++ b/job_scraper/kois/agreement_signals.py
@@ -1,35 +1,62 @@
 from __future__ import annotations
 
+import re
+
 from job_scraper.kois.schema import ExtractedRecord, RawSourceItem
 from job_scraper.kois.utils import normalize_text
 
 
-AGREEMENT_KEYWORDS = ("dps", "frame", "framework", "agreement", "rammeavtale")
+AGREEMENT_PHRASES = (
+    "dps",
+    "dynamic purchasing system",
+    "frame agreement",
+    "framework agreement",
+    "rammeavtale",
+    "ramme avtale",
+)
 
 
-def _looks_like_agreement(metadata: dict, record: ExtractedRecord) -> bool:
-    agreement_type = normalize_text(metadata.get("agreement_type"))
-    notice_type = normalize_text(metadata.get("notice_type"))
-    haystack = " ".join(
-        value
-        for value in (
-            agreement_type,
-            notice_type,
-            normalize_text(record.title),
-            normalize_text(record.description),
-        )
-        if value
+def _contains_agreement_phrase(text: str | None) -> bool:
+    normalized = normalize_text(text)
+    if not normalized:
+        return False
+    return any(
+        re.search(rf"\b{re.escape(keyword)}\b", normalized) for keyword in AGREEMENT_PHRASES
     )
-    return any(keyword in haystack for keyword in AGREEMENT_KEYWORDS)
+
+
+def _looks_like_agreement(
+    metadata: dict, notice_payload: dict, record: ExtractedRecord
+) -> bool:
+    agreement_type = normalize_text(
+        notice_payload.get("agreement_type")
+        or metadata.get("agreement_type")
+        or record.extracted_data.get("agreement_type")
+    )
+    notice_type = normalize_text(
+        notice_payload.get("notice_type")
+        or metadata.get("notice_type")
+        or record.extracted_data.get("notice_type")
+    )
+    title = normalize_text(notice_payload.get("title") or record.title)
+    return any(
+        (
+            _contains_agreement_phrase(agreement_type),
+            _contains_agreement_phrase(notice_type),
+            _contains_agreement_phrase(title),
+        )
+    )
 
 
 def build_agreement_signal_payload(
     raw_item: RawSourceItem, record: ExtractedRecord
 ) -> dict | None:
-    metadata = raw_item.metadata_json or {}
-    if not _looks_like_agreement(metadata, record):
+    if raw_item.source_type != "procurement":
         return None
+    metadata = raw_item.metadata_json or {}
     notice_payload = metadata.get("notice_payload") or {}
+    if not _looks_like_agreement(metadata, notice_payload, record):
+        return None
     return {
         "raw_source_item_id": raw_item.id,
         "source_name": raw_item.source_name,

--- a/job_scraper/kois/agreement_signals.py
+++ b/job_scraper/kois/agreement_signals.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import re
 
-from job_scraper.kois.schema import ExtractedRecord, RawSourceItem
+from sqlalchemy.orm import Session
+
+from job_scraper.kois.repository import delete_agreement_signal, upsert_agreement_signal
+from job_scraper.kois.schema import AgreementSignal, ExtractedRecord, RawSourceItem
 from job_scraper.kois.utils import normalize_text
 
 
@@ -86,3 +89,19 @@ def build_agreement_signal_payload(
             "raw_source_type": raw_item.source_type,
         },
     }
+
+
+def sync_procurement_agreement_signal(
+    session: Session, raw_item: RawSourceItem, record: ExtractedRecord
+) -> AgreementSignal | None:
+    if raw_item.source_type != "procurement":
+        return None
+    signal_payload = build_agreement_signal_payload(raw_item=raw_item, record=record)
+    if signal_payload:
+        return upsert_agreement_signal(session, signal_payload)
+    delete_agreement_signal(
+        session,
+        source_name=raw_item.source_name,
+        external_id=raw_item.external_id,
+    )
+    return None

--- a/job_scraper/kois/agreement_signals.py
+++ b/job_scraper/kois/agreement_signals.py
@@ -9,8 +9,11 @@ from job_scraper.kois.utils import normalize_text
 AGREEMENT_PHRASES = (
     "dps",
     "dynamic purchasing system",
+    "frame",
     "frame agreement",
+    "framework",
     "framework agreement",
+    "ramme",
     "rammeavtale",
     "ramme avtale",
 )
@@ -20,6 +23,9 @@ def _contains_agreement_phrase(text: str | None) -> bool:
     normalized = normalize_text(text)
     if not normalized:
         return False
+    # Procurement feeds often provide compact agreement labels ("frame", "dps").
+    if normalized in AGREEMENT_PHRASES:
+        return True
     return any(
         re.search(rf"\b{re.escape(keyword)}\b", normalized) for keyword in AGREEMENT_PHRASES
     )

--- a/job_scraper/kois/agreement_signals.py
+++ b/job_scraper/kois/agreement_signals.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from job_scraper.kois.schema import ExtractedRecord, RawSourceItem
+from job_scraper.kois.utils import normalize_text
+
+
+AGREEMENT_KEYWORDS = ("dps", "frame", "framework", "agreement", "rammeavtale")
+
+
+def _looks_like_agreement(metadata: dict, record: ExtractedRecord) -> bool:
+    agreement_type = normalize_text(metadata.get("agreement_type"))
+    notice_type = normalize_text(metadata.get("notice_type"))
+    haystack = " ".join(
+        value
+        for value in (
+            agreement_type,
+            notice_type,
+            normalize_text(record.title),
+            normalize_text(record.description),
+        )
+        if value
+    )
+    return any(keyword in haystack for keyword in AGREEMENT_KEYWORDS)
+
+
+def build_agreement_signal_payload(
+    raw_item: RawSourceItem, record: ExtractedRecord
+) -> dict | None:
+    metadata = raw_item.metadata_json or {}
+    if not _looks_like_agreement(metadata, record):
+        return None
+    notice_payload = metadata.get("notice_payload") or {}
+    return {
+        "raw_source_item_id": raw_item.id,
+        "source_name": raw_item.source_name,
+        "external_id": raw_item.external_id,
+        "title": record.title,
+        "buyer_name": record.customer,
+        "agreement_type": normalize_text(
+            notice_payload.get("agreement_type")
+            or record.extracted_data.get("agreement_type")
+            or "unspecified"
+        ),
+        "category": notice_payload.get("category") or record.extracted_data.get("category"),
+        "status": normalize_text(notice_payload.get("status")),
+        "source_url": record.source_url,
+        "published_at": notice_payload.get("published_at"),
+        "deadline": record.deadline,
+        "signal_confidence": record.extraction_confidence or 0.6,
+        "metadata_json": {
+            "source_kind": record.extracted_data.get("source_kind"),
+            "notice_type": notice_payload.get("notice_type"),
+            "raw_source_type": raw_item.source_type,
+        },
+    }

--- a/job_scraper/kois/analytics.py
+++ b/job_scraper/kois/analytics.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from job_scraper.kois.schema import (
+    AgreementGap,
+    AgreementSignal,
+    ClusterSource,
+    ExtractedRecord,
+    GapStatus,
+    OpportunityCluster,
+    SourceComparison,
+)
+
+
+def buyer_trends(session: Session, limit: int = 10) -> list[dict]:
+    rows = session.execute(
+        select(
+            OpportunityCluster.customer.label("buyer"),
+            func.count(OpportunityCluster.id).label("opportunity_count"),
+            func.avg(OpportunityCluster.confidence).label("avg_confidence"),
+        )
+        .where(OpportunityCluster.customer.is_not(None))
+        .group_by(OpportunityCluster.customer)
+        .order_by(func.count(OpportunityCluster.id).desc())
+        .limit(limit)
+    )
+    return [
+        {
+            "buyer": row.buyer,
+            "opportunity_count": int(row.opportunity_count),
+            "avg_confidence": float(row.avg_confidence or 0.0),
+        }
+        for row in rows
+    ]
+
+
+def broker_patterns(session: Session, limit: int = 10) -> list[dict]:
+    rows = session.execute(
+        select(
+            ExtractedRecord.broker.label("broker"),
+            func.count(ExtractedRecord.id).label("record_count"),
+            func.count(func.distinct(ExtractedRecord.customer)).label("unique_buyers"),
+        )
+        .where(ExtractedRecord.broker.is_not(None))
+        .group_by(ExtractedRecord.broker)
+        .order_by(func.count(ExtractedRecord.id).desc())
+        .limit(limit)
+    )
+    return [
+        {
+            "broker": row.broker,
+            "record_count": int(row.record_count),
+            "unique_buyers": int(row.unique_buyers),
+        }
+        for row in rows
+    ]
+
+
+def source_quality_summary(session: Session) -> dict:
+    cluster_count = session.execute(
+        select(func.count(OpportunityCluster.id))
+    ).scalar_one()
+    comparison_cluster_count = session.execute(
+        select(func.count(func.distinct(SourceComparison.opportunity_cluster_id)))
+    ).scalar_one()
+    source_counts = (
+        select(
+            ClusterSource.opportunity_cluster_id,
+            func.count(ClusterSource.id).label("count_per_cluster"),
+        )
+        .group_by(ClusterSource.opportunity_cluster_id)
+        .subquery()
+    )
+    avg_source_count = session.execute(
+        select(func.avg(source_counts.c.count_per_cluster))
+    ).scalar_one_or_none()
+    comparison_ratio = (
+        float(comparison_cluster_count) / float(cluster_count)
+        if cluster_count
+        else 0.0
+    )
+    return {
+        "cluster_count": int(cluster_count),
+        "clusters_with_conflicts": int(comparison_cluster_count),
+        "conflict_ratio": comparison_ratio,
+        "average_sources_per_cluster": float(avg_source_count or 0.0),
+    }
+
+
+def agreement_coverage_summary(session: Session) -> dict:
+    signal_count = session.execute(select(func.count(AgreementSignal.id))).scalar_one()
+    gap_count = session.execute(select(func.count(AgreementGap.id))).scalar_one()
+    open_gap_count = session.execute(
+        select(func.count(AgreementGap.id)).where(AgreementGap.status == GapStatus.OPEN)
+    ).scalar_one()
+    return {
+        "agreement_signal_count": int(signal_count),
+        "gap_count": int(gap_count),
+        "open_gap_count": int(open_gap_count),
+    }
+
+
+def phase2_summary(session: Session) -> dict:
+    return {
+        "buyer_trends": buyer_trends(session),
+        "broker_patterns": broker_patterns(session),
+        "source_quality": source_quality_summary(session),
+        "coverage": agreement_coverage_summary(session),
+    }

--- a/job_scraper/kois/clustering.py
+++ b/job_scraper/kois/clustering.py
@@ -21,12 +21,11 @@ from job_scraper.kois.utils import normalize_text, normalize_url
 
 
 SOURCE_PRIORITY = {
-    "doffin": 100,
-    "procurement": 90,
+    "public_tender": 100,
+    "procurement_platform": 90,
     "direct": 80,
     "broker": 70,
-    "email": 60,
-    "forwarded": 50,
+    "email_forwarded": 60,
     "manual": 40,
     "unknown": 10,
 }
@@ -34,6 +33,10 @@ SOURCE_PRIORITY = {
 
 def _source_priority_key(record: ExtractedRecord) -> str:
     extracted_data = record.extracted_data or {}
+    canonical = normalize_text(extracted_data.get("source_kind"))
+    if canonical in SOURCE_PRIORITY:
+        return canonical
+
     source_type = normalize_text(extracted_data.get("source_type"))
     platform = normalize_text(extracted_data.get("platform"))
     host = normalize_text(extracted_data.get("host"))
@@ -44,13 +47,11 @@ def _source_priority_key(record: ExtractedRecord) -> str:
     )
 
     if "doffin" in fingerprint:
-        return "doffin"
+        return "public_tender"
     if "procurement" in fingerprint:
-        return "procurement"
+        return "procurement_platform"
     if source_type == "email" or "@" in broker:
-        return "email"
-    if "forwarded" in fingerprint or "forward" in fingerprint:
-        return "forwarded"
+        return "email_forwarded"
     if "manual" in fingerprint:
         return "manual"
     if source_type == "scraper" or "broker" in fingerprint:

--- a/job_scraper/kois/clustering.py
+++ b/job_scraper/kois/clustering.py
@@ -26,6 +26,7 @@ SOURCE_PRIORITY = {
     "direct": 80,
     "broker": 70,
     "email_forwarded": 60,
+    "forwarded": 50,
     "manual": 40,
     "unknown": 10,
 }
@@ -52,6 +53,8 @@ def _source_priority_key(record: ExtractedRecord) -> str:
         return "procurement_platform"
     if source_type == "email" or "@" in broker:
         return "email_forwarded"
+    if "forwarded" in fingerprint or "forward" in fingerprint:
+        return "forwarded"
     if "manual" in fingerprint:
         return "manual"
     if source_type == "scraper" or "broker" in fingerprint:

--- a/job_scraper/kois/config.py
+++ b/job_scraper/kois/config.py
@@ -26,6 +26,12 @@ class KOISSettings(BaseSettings):
     imap_since_uid: int = 1
     imap_source_name: str = "oppdrag@kynd.no"
 
+    doffin_feed_url: str | None = None
+    doffin_feed_json: str | None = None
+    procurement_feed_urls_by_source: dict[str, str] = Field(default_factory=dict)
+    procurement_feed_json_by_source: dict[str, str] = Field(default_factory=dict)
+    agreement_gap_min_cluster_hits: int = 2
+
     run_live_slack: bool = False
 
 

--- a/job_scraper/kois/domain.py
+++ b/job_scraper/kois/domain.py
@@ -23,6 +23,7 @@ class SourceKind(str, Enum):
     DIRECT = "direct"
     BROKER = "broker"
     EMAIL_FORWARDED = "email_forwarded"
+    FORWARDED = "forwarded"
     MANUAL = "manual"
     UNKNOWN = "unknown"
 
@@ -53,6 +54,8 @@ def infer_source_kind(
         return SourceKind.PROCUREMENT_PLATFORM
     if "procurement" in fingerprint or "anskaff" in fingerprint:
         return SourceKind.PROCUREMENT_PLATFORM
+    if "forwarded" in fingerprint or "forward" in fingerprint:
+        return SourceKind.FORWARDED
     if source_type_value in {"scraper", "broker"}:
         return SourceKind.BROKER
     if "direct" in fingerprint:

--- a/job_scraper/kois/domain.py
+++ b/job_scraper/kois/domain.py
@@ -47,14 +47,16 @@ def infer_source_kind(
 
     if "doffin" in fingerprint:
         return SourceKind.PUBLIC_TENDER
-    if "procurement" in fingerprint or "tender" in fingerprint:
-        return SourceKind.PROCUREMENT_PLATFORM
     if source_type_value == "email":
         return SourceKind.EMAIL_FORWARDED
+    if source_type_value == "procurement":
+        return SourceKind.PROCUREMENT_PLATFORM
+    if "procurement" in fingerprint or "anskaff" in fingerprint:
+        return SourceKind.PROCUREMENT_PLATFORM
+    if source_type_value in {"scraper", "broker"}:
+        return SourceKind.BROKER
     if "direct" in fingerprint:
         return SourceKind.DIRECT
     if "manual" in fingerprint:
         return SourceKind.MANUAL
-    if source_type_value in {"scraper", "procurement"}:
-        return SourceKind.BROKER
     return SourceKind.UNKNOWN

--- a/job_scraper/kois/domain.py
+++ b/job_scraper/kois/domain.py
@@ -1,5 +1,10 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from enum import Enum
+
+from job_scraper.kois.utils import normalize_text
 
 
 @dataclass
@@ -10,3 +15,46 @@ class RawIngestionItem:
     raw_body: str
     metadata: dict = field(default_factory=dict)
     received_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class SourceKind(str, Enum):
+    PUBLIC_TENDER = "public_tender"
+    PROCUREMENT_PLATFORM = "procurement_platform"
+    DIRECT = "direct"
+    BROKER = "broker"
+    EMAIL_FORWARDED = "email_forwarded"
+    MANUAL = "manual"
+    UNKNOWN = "unknown"
+
+
+def infer_source_kind(
+    source_type: str | None, source_name: str | None, metadata: dict | None = None
+) -> SourceKind:
+    metadata = metadata or {}
+    source_type_value = normalize_text(source_type)
+    source_name_value = normalize_text(source_name)
+    fingerprint = " ".join(
+        value
+        for value in (
+            source_type_value,
+            source_name_value,
+            normalize_text(metadata.get("platform")),
+            normalize_text(metadata.get("host")),
+            normalize_text(metadata.get("origin")),
+        )
+        if value
+    )
+
+    if "doffin" in fingerprint:
+        return SourceKind.PUBLIC_TENDER
+    if "procurement" in fingerprint or "tender" in fingerprint:
+        return SourceKind.PROCUREMENT_PLATFORM
+    if source_type_value == "email":
+        return SourceKind.EMAIL_FORWARDED
+    if "direct" in fingerprint:
+        return SourceKind.DIRECT
+    if "manual" in fingerprint:
+        return SourceKind.MANUAL
+    if source_type_value in {"scraper", "procurement"}:
+        return SourceKind.BROKER
+    return SourceKind.UNKNOWN

--- a/job_scraper/kois/extraction.py
+++ b/job_scraper/kois/extraction.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 from urllib.parse import urlparse
 
+from job_scraper.kois.domain import infer_source_kind
 from job_scraper.models import Job
 from job_scraper.kois.schema import RawSourceItem
 from job_scraper.kois.utils import normalize_text, normalize_url
@@ -22,6 +23,11 @@ class RecordExtractor:
         body = raw_source.raw_body
         metadata = raw_source.metadata_json or {}
         subject = metadata.get("subject")
+        source_kind = infer_source_kind(
+            raw_source.source_type,
+            raw_source.source_name,
+            metadata,
+        )
 
         title_match = TITLE_PATTERN.search(subject or "") or TITLE_PATTERN.search(body)
         deadline_match = DEADLINE_PATTERN.search(body)
@@ -44,6 +50,7 @@ class RecordExtractor:
             "extracted_data": {
                 "source_type": "email",
                 "metadata": metadata,
+                "source_kind": source_kind.value,
                 "raw_content_hash": raw_source.content_hash,
             },
         }
@@ -54,6 +61,11 @@ class RecordExtractor:
         summary = job.description_summarised
         if not summary and self.summarizer:
             summary = self.summarizer.summarize(description)
+        source_kind = infer_source_kind(
+            raw_source.source_type,
+            raw_source.source_name,
+            raw_source.metadata_json,
+        )
         return {
             "raw_source_item_id": raw_source.id,
             "title": job.job_overview.title,
@@ -68,6 +80,38 @@ class RecordExtractor:
                 "source_type": "scraper",
                 "platform": job.platform,
                 "host": urlparse(job.job_overview.job_uri or "").hostname,
+                "source_kind": source_kind.value,
+                "raw_content_hash": raw_source.content_hash,
+            },
+        }
+
+    def _extract_procurement(self, raw_source: RawSourceItem) -> dict:
+        metadata = raw_source.metadata_json or {}
+        payload = metadata.get("notice_payload") or {}
+        source_url = payload.get("url") or payload.get("source_url")
+        source_kind = infer_source_kind(
+            raw_source.source_type,
+            raw_source.source_name,
+            metadata,
+        )
+
+        return {
+            "raw_source_item_id": raw_source.id,
+            "title": payload.get("title") or metadata.get("title"),
+            "customer": payload.get("buyer") or payload.get("customer"),
+            "broker": raw_source.source_name,
+            "source_url": source_url,
+            "deadline": payload.get("deadline"),
+            "description": payload.get("description") or raw_source.raw_body,
+            "summary": payload.get("summary"),
+            "extraction_confidence": 0.85,
+            "extracted_data": {
+                "source_type": "procurement",
+                "source_kind": source_kind.value,
+                "agreement_type": payload.get("agreement_type"),
+                "notice_type": payload.get("notice_type"),
+                "category": payload.get("category"),
+                "host": urlparse(source_url or "").hostname,
                 "raw_content_hash": raw_source.content_hash,
             },
         }
@@ -75,6 +119,8 @@ class RecordExtractor:
     def extract(self, raw_source: RawSourceItem) -> dict:
         if raw_source.source_type == "email":
             return self._extract_email(raw_source)
+        if raw_source.source_type == "procurement":
+            return self._extract_procurement(raw_source)
 
         return self._extract_scraper(raw_source)
 

--- a/job_scraper/kois/gaps.py
+++ b/job_scraper/kois/gaps.py
@@ -84,6 +84,7 @@ def set_gap_status(
     if not gap:
         raise ValueError(f"Agreement gap {gap_id} not found")
     gap.status = status
-    gap.note = note
+    if note is not None:
+        gap.note = note
     session.flush()
     return gap

--- a/job_scraper/kois/gaps.py
+++ b/job_scraper/kois/gaps.py
@@ -5,7 +5,10 @@ from collections import defaultdict
 from sqlalchemy import exists, select
 from sqlalchemy.orm import Session
 
-from job_scraper.kois.repository import upsert_agreement_gap
+from job_scraper.kois.repository import (
+    AGREEMENT_GAP_AUTO_CLOSE_NOTE,
+    upsert_agreement_gap,
+)
 from job_scraper.kois.schema import (
     AgreementGap,
     AgreementSignal,
@@ -56,9 +59,7 @@ def discover_missing_agreement_gaps(
                 if gap.status not in {GapStatus.OPEN, GapStatus.ACKNOWLEDGED}:
                     continue
                 gap.status = GapStatus.IGNORED
-                gap.note = (
-                    "Auto-closed after matching agreement signal detected for this buyer."
-                )
+                gap.note = AGREEMENT_GAP_AUTO_CLOSE_NOTE
                 session.flush()
                 persisted.append(gap)
             continue

--- a/job_scraper/kois/gaps.py
+++ b/job_scraper/kois/gaps.py
@@ -36,10 +36,25 @@ def discover_missing_agreement_gaps(
         clusters_by_buyer[buyer_key].append(cluster)
 
     persisted: list[AgreementGap] = []
+    existing_gaps_by_buyer: dict[str, list[AgreementGap]] = defaultdict(list)
+    for gap in session.execute(select(AgreementGap)).scalars():
+        buyer_key = normalize_text(gap.buyer_name)
+        if buyer_key:
+            existing_gaps_by_buyer[buyer_key].append(gap)
+
     for buyer_key, clusters in clusters_by_buyer.items():
-        if len(clusters) < min_cluster_hits:
-            continue
         if buyer_key in buyers_with_agreements:
+            for gap in existing_gaps_by_buyer.get(buyer_key, []):
+                if gap.status not in {GapStatus.OPEN, GapStatus.ACKNOWLEDGED}:
+                    continue
+                gap.status = GapStatus.IGNORED
+                gap.note = (
+                    "Auto-closed after matching agreement signal detected for this buyer."
+                )
+                session.flush()
+                persisted.append(gap)
+            continue
+        if len(clusters) < min_cluster_hits:
             continue
 
         buyer_name = clusters[0].customer or buyer_key

--- a/job_scraper/kois/gaps.py
+++ b/job_scraper/kois/gaps.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from collections import defaultdict
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from job_scraper.kois.repository import upsert_agreement_gap
+from job_scraper.kois.schema import (
+    AgreementGap,
+    AgreementSignal,
+    GapStatus,
+    OpportunityCluster,
+)
+from job_scraper.kois.utils import normalize_text
+
+
+def discover_missing_agreement_gaps(
+    session: Session, min_cluster_hits: int = 2
+) -> list[AgreementGap]:
+    buyers_with_agreements = {
+        normalize_text(buyer)
+        for buyer in session.execute(
+            select(AgreementSignal.buyer_name).where(AgreementSignal.buyer_name.is_not(None))
+        ).scalars()
+        if normalize_text(buyer)
+    }
+
+    clusters_by_buyer: dict[str, list[OpportunityCluster]] = defaultdict(list)
+    for cluster in session.execute(
+        select(OpportunityCluster).where(OpportunityCluster.customer.is_not(None))
+    ).scalars():
+        buyer_key = normalize_text(cluster.customer)
+        if not buyer_key:
+            continue
+        clusters_by_buyer[buyer_key].append(cluster)
+
+    persisted: list[AgreementGap] = []
+    for buyer_key, clusters in clusters_by_buyer.items():
+        if len(clusters) < min_cluster_hits:
+            continue
+        if buyer_key in buyers_with_agreements:
+            continue
+
+        buyer_name = clusters[0].customer or buyer_key
+        payload = {
+            "gap_key": f"buyer:{buyer_key}",
+            "buyer_name": buyer_name,
+            "status": GapStatus.OPEN,
+            "confidence": min(0.99, 0.55 + 0.1 * len(clusters)),
+            "rationale": "Repeated buyer demand without matching DPS/frame agreement signal.",
+            "evidence_json": {
+                "cluster_ids": [cluster.id for cluster in clusters],
+                "cluster_count": len(clusters),
+            },
+        }
+        persisted.append(upsert_agreement_gap(session, payload))
+    return persisted
+
+
+def set_gap_status(
+    session: Session,
+    gap_id: int,
+    status: GapStatus,
+    actor: str = "reviewer",
+    note: str | None = None,
+) -> AgreementGap:
+    gap = session.get(AgreementGap, gap_id)
+    if not gap:
+        raise ValueError(f"Agreement gap {gap_id} not found")
+    gap.status = status
+    gap.note = note
+    session.flush()
+    return gap

--- a/job_scraper/kois/gaps.py
+++ b/job_scraper/kois/gaps.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 from collections import defaultdict
 
-from sqlalchemy import select
+from sqlalchemy import exists, select
 from sqlalchemy.orm import Session
 
 from job_scraper.kois.repository import upsert_agreement_gap
 from job_scraper.kois.schema import (
     AgreementGap,
     AgreementSignal,
+    ClusterSource,
     GapStatus,
     OpportunityCluster,
 )
@@ -28,7 +29,14 @@ def discover_missing_agreement_gaps(
 
     clusters_by_buyer: dict[str, list[OpportunityCluster]] = defaultdict(list)
     for cluster in session.execute(
-        select(OpportunityCluster).where(OpportunityCluster.customer.is_not(None))
+        select(OpportunityCluster).where(
+            OpportunityCluster.customer.is_not(None),
+            exists(
+                select(ClusterSource.id).where(
+                    ClusterSource.opportunity_cluster_id == OpportunityCluster.id
+                )
+            ),
+        )
     ).scalars():
         buyer_key = normalize_text(cluster.customer)
         if not buyer_key:

--- a/job_scraper/kois/ingestion/procurement_adapter.py
+++ b/job_scraper/kois/ingestion/procurement_adapter.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from urllib.request import Request, urlopen
+
+from job_scraper.kois.config import KOISSettings
+from job_scraper.kois.domain import RawIngestionItem
+from job_scraper.kois.utils import content_hash, normalize_text
+
+
+def _load_json_url(url: str) -> list[dict]:
+    request = Request(url=url, headers={"Accept": "application/json"})
+    with urlopen(request, timeout=20) as response:  # noqa: S310
+        payload = json.loads(response.read().decode("utf-8"))
+    if isinstance(payload, dict):
+        return payload.get("items", [])
+    if isinstance(payload, list):
+        return payload
+    return []
+
+
+def _parse_embedded_json(payload: str | None) -> list[dict]:
+    if not payload:
+        return []
+    try:
+        parsed = json.loads(payload)
+    except json.JSONDecodeError:
+        return []
+    if isinstance(parsed, dict):
+        return parsed.get("items", [])
+    if isinstance(parsed, list):
+        return parsed
+    return []
+
+
+def _normalize_notice(source_name: str, notice: dict) -> RawIngestionItem:
+    payload = dict(notice)
+    external_id = (
+        str(
+            notice.get("id")
+            or notice.get("notice_id")
+            or notice.get("external_id")
+            or notice.get("url")
+            or content_hash(json.dumps(notice, sort_keys=True))
+        )
+    )
+    title = notice.get("title")
+    source_url = notice.get("url") or notice.get("source_url")
+    metadata = {
+        "title": title,
+        "url": source_url,
+        "buyer": notice.get("buyer") or notice.get("customer"),
+        "agreement_type": normalize_text(notice.get("agreement_type")),
+        "notice_type": normalize_text(notice.get("notice_type")),
+        "category": notice.get("category"),
+        "origin": source_name,
+        "notice_payload": payload,
+    }
+    return RawIngestionItem(
+        source_type="procurement",
+        source_name=source_name,
+        external_id=external_id,
+        raw_body=json.dumps(payload, ensure_ascii=False, sort_keys=True),
+        metadata=metadata,
+        received_at=datetime.now(timezone.utc),
+    )
+
+
+def fetch_procurement_items(settings: KOISSettings) -> list[RawIngestionItem]:
+    notices_by_source: dict[str, list[dict]] = {}
+
+    doffin_feed_json = getattr(settings, "doffin_feed_json", None)
+    doffin_feed_url = getattr(settings, "doffin_feed_url", None)
+    procurement_feed_json_by_source = getattr(
+        settings, "procurement_feed_json_by_source", {}
+    ) or {}
+    procurement_feed_urls_by_source = getattr(
+        settings, "procurement_feed_urls_by_source", {}
+    ) or {}
+
+    doffin_embedded = _parse_embedded_json(doffin_feed_json)
+    if doffin_embedded:
+        notices_by_source["doffin"] = doffin_embedded
+    elif doffin_feed_url:
+        try:
+            notices_by_source["doffin"] = _load_json_url(doffin_feed_url)
+        except Exception:  # noqa: BLE001
+            notices_by_source["doffin"] = []
+
+    for source_name, source_payload in procurement_feed_json_by_source.items():
+        notices_by_source[source_name] = _parse_embedded_json(source_payload)
+
+    for source_name, source_url in procurement_feed_urls_by_source.items():
+        if source_name in notices_by_source and notices_by_source[source_name]:
+            continue
+        try:
+            notices_by_source[source_name] = _load_json_url(source_url)
+        except Exception:  # noqa: BLE001
+            notices_by_source[source_name] = []
+
+    raw_items: list[RawIngestionItem] = []
+    for source_name, notices in notices_by_source.items():
+        for notice in notices:
+            if not isinstance(notice, dict):
+                continue
+            raw_items.append(_normalize_notice(source_name=source_name, notice=notice))
+    return raw_items

--- a/job_scraper/kois/migrations.py
+++ b/job_scraper/kois/migrations.py
@@ -8,6 +8,7 @@ from job_scraper.kois import schema  # noqa: F401
 
 INIT_MIGRATION_ID = "20260605_kois_phase1_init"
 DROP_CONTENT_HASH_UNIQUE_MIGRATION_ID = "20260606_drop_raw_source_content_hash_unique"
+PHASE2_INTELLIGENCE_MIGRATION_ID = "20260606_phase2_agreements_and_gaps"
 
 
 def _ensure_migrations_table(connection) -> None:
@@ -54,9 +55,15 @@ def _drop_content_hash_unique(connection) -> None:
     )
 
 
+def _add_phase2_tables(connection) -> None:
+    schema.AgreementSignal.__table__.create(bind=connection, checkfirst=True)
+    schema.AgreementGap.__table__.create(bind=connection, checkfirst=True)
+
+
 MIGRATIONS: list[tuple[str, Callable]] = [
     (INIT_MIGRATION_ID, _run_init),
     (DROP_CONTENT_HASH_UNIQUE_MIGRATION_ID, _drop_content_hash_unique),
+    (PHASE2_INTELLIGENCE_MIGRATION_ID, _add_phase2_tables),
 ]
 
 

--- a/job_scraper/kois/orchestrator.py
+++ b/job_scraper/kois/orchestrator.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 
 from sqlalchemy.orm import Session
 
-from job_scraper.kois.agreement_signals import build_agreement_signal_payload
+from job_scraper.kois.agreement_signals import sync_procurement_agreement_signal
 from job_scraper.kois.clustering import cluster_records, refresh_clusters
 from job_scraper.kois.config import get_settings
 from job_scraper.kois.digest import send_digest_items
@@ -20,7 +20,6 @@ from job_scraper.kois.repository import (
     detach_record_cluster_sources,
     get_extracted_record_for_raw_source,
     list_clusters_with_unsent_digests,
-    upsert_agreement_signal,
     upsert_raw_source_item,
 )
 from job_scraper.models import Job
@@ -81,9 +80,7 @@ def run_kois_pipeline(
         record = record_by_raw_source_id.get(raw_item.id)
         if record is None:
             continue
-        signal_payload = build_agreement_signal_payload(raw_item=raw_item, record=record)
-        if signal_payload:
-            upsert_agreement_signal(session, signal_payload)
+        sync_procurement_agreement_signal(session, raw_item=raw_item, record=record)
     discovered_gaps = discover_missing_agreement_gaps(
         session,
         min_cluster_hits=getattr(settings, "agreement_gap_min_cluster_hits", 2),

--- a/job_scraper/kois/orchestrator.py
+++ b/job_scraper/kois/orchestrator.py
@@ -5,18 +5,22 @@ from collections.abc import Iterable
 
 from sqlalchemy.orm import Session
 
+from job_scraper.kois.agreement_signals import build_agreement_signal_payload
 from job_scraper.kois.clustering import cluster_records, refresh_clusters
 from job_scraper.kois.config import get_settings
 from job_scraper.kois.digest import send_digest_items
 from job_scraper.kois.domain import RawIngestionItem
 from job_scraper.kois.extraction import RecordExtractor
+from job_scraper.kois.gaps import discover_missing_agreement_gaps
 from job_scraper.kois.ingestion.imap_adapter import fetch_imap_items
+from job_scraper.kois.ingestion.procurement_adapter import fetch_procurement_items
 from job_scraper.kois.ingestion.scraper_adapter import jobs_to_raw_items
 from job_scraper.kois.repository import (
     create_extracted_record,
     detach_record_cluster_sources,
     get_extracted_record_for_raw_source,
     list_clusters_with_unsent_digests,
+    upsert_agreement_signal,
     upsert_raw_source_item,
 )
 from job_scraper.models import Job
@@ -39,6 +43,7 @@ def run_kois_pipeline(
     ingestion_items: list[RawIngestionItem] = []
     ingestion_items.extend(jobs_to_raw_items(scraped_jobs))
     ingestion_items.extend(fetch_imap_items(settings))
+    ingestion_items.extend(fetch_procurement_items(settings))
 
     raw_items = [upsert_raw_source_item(session, item) for item in ingestion_items]
 
@@ -49,16 +54,19 @@ def run_kois_pipeline(
     )
     extractor = RecordExtractor(summarizer=summarizer)
     records = []
+    record_by_raw_source_id: dict[int, object] = {}
     clusters_from_failed_extraction: list = []
     for raw_item in raw_items:
         existing_record = get_extracted_record_for_raw_source(session, raw_item.id)
         if existing_record and _record_matches_raw_content(raw_item, existing_record):
             records.append(existing_record)
+            record_by_raw_source_id[raw_item.id] = existing_record
             continue
         try:
             payload = extractor.extract(raw_item)
             record = create_extracted_record(session, payload)
             records.append(record)
+            record_by_raw_source_id[raw_item.id] = record
         except Exception as exc:  # noqa: BLE001
             logger.exception("Extraction failed for raw source %s", raw_item.id)
             raw_item.extraction_error = str(exc)
@@ -69,6 +77,17 @@ def run_kois_pipeline(
                 )
 
     touched_clusters = cluster_records(session, records)
+    for raw_item in raw_items:
+        record = record_by_raw_source_id.get(raw_item.id)
+        if record is None:
+            continue
+        signal_payload = build_agreement_signal_payload(raw_item=raw_item, record=record)
+        if signal_payload:
+            upsert_agreement_signal(session, signal_payload)
+    discovered_gaps = discover_missing_agreement_gaps(
+        session,
+        min_cluster_hits=getattr(settings, "agreement_gap_min_cluster_hits", 2),
+    )
     if clusters_from_failed_extraction:
         refresh_clusters(session, clusters_from_failed_extraction)
         touched_clusters = [*touched_clusters, *clusters_from_failed_extraction]
@@ -89,5 +108,6 @@ def run_kois_pipeline(
         "raw_items": len(raw_items),
         "records": len(records),
         "clusters": len({cluster.id for cluster in touched_clusters}),
+        "gaps": len(discovered_gaps),
         "digests": len(digests),
     }

--- a/job_scraper/kois/repository.py
+++ b/job_scraper/kois/repository.py
@@ -349,7 +349,7 @@ def upsert_agreement_gap(session: Session, payload: dict) -> AgreementGap:
         existing.confidence = payload["confidence"]
         existing.rationale = payload["rationale"]
         existing.evidence_json = payload["evidence_json"]
-        if existing.status in {GapStatus.OPEN, GapStatus.ACKNOWLEDGED}:
+        if existing.status == GapStatus.OPEN:
             existing.status = payload.get("status", GapStatus.OPEN)
         session.flush()
         return existing

--- a/job_scraper/kois/repository.py
+++ b/job_scraper/kois/repository.py
@@ -7,9 +7,12 @@ from sqlalchemy.orm import Session
 
 from job_scraper.kois.domain import RawIngestionItem
 from job_scraper.kois.schema import (
+    AgreementGap,
+    AgreementSignal,
     ClusterSource,
     DigestItem,
     ExtractedRecord,
+    GapStatus,
     OpportunityCluster,
     RawSourceItem,
     ReviewState,
@@ -293,3 +296,74 @@ def list_clusters_with_unsent_digests(session: Session) -> list[OpportunityClust
             .distinct()
         ).scalars()
     )
+
+
+def upsert_agreement_signal(session: Session, payload: dict) -> AgreementSignal:
+    existing = session.execute(
+        select(AgreementSignal).where(
+            AgreementSignal.source_name == payload["source_name"],
+            AgreementSignal.external_id == payload["external_id"],
+        )
+    ).scalar_one_or_none()
+    if existing:
+        existing.raw_source_item_id = payload["raw_source_item_id"]
+        existing.title = payload.get("title")
+        existing.buyer_name = payload.get("buyer_name")
+        existing.agreement_type = payload.get("agreement_type")
+        existing.category = payload.get("category")
+        existing.status = payload.get("status")
+        existing.source_url = payload.get("source_url")
+        existing.published_at = payload.get("published_at")
+        existing.deadline = payload.get("deadline")
+        existing.signal_confidence = payload.get("signal_confidence", 0.0)
+        existing.metadata_json = payload.get("metadata_json", {})
+        session.flush()
+        return existing
+
+    created = AgreementSignal(**payload)
+    session.add(created)
+    session.flush()
+    return created
+
+
+def list_agreement_signals(
+    session: Session,
+    buyer_name: str | None = None,
+    agreement_type: str | None = None,
+    limit: int = 50,
+) -> list[AgreementSignal]:
+    query = select(AgreementSignal).order_by(AgreementSignal.updated_at.desc())
+    if buyer_name:
+        query = query.where(AgreementSignal.buyer_name.ilike(f"%{buyer_name}%"))
+    if agreement_type:
+        query = query.where(AgreementSignal.agreement_type == agreement_type)
+    return list(session.execute(query.limit(limit)).scalars())
+
+
+def upsert_agreement_gap(session: Session, payload: dict) -> AgreementGap:
+    existing = session.execute(
+        select(AgreementGap).where(AgreementGap.gap_key == payload["gap_key"])
+    ).scalar_one_or_none()
+    if existing:
+        existing.buyer_name = payload["buyer_name"]
+        existing.confidence = payload["confidence"]
+        existing.rationale = payload["rationale"]
+        existing.evidence_json = payload["evidence_json"]
+        if existing.status in {GapStatus.OPEN, GapStatus.ACKNOWLEDGED}:
+            existing.status = payload.get("status", GapStatus.OPEN)
+        session.flush()
+        return existing
+
+    created = AgreementGap(**payload)
+    session.add(created)
+    session.flush()
+    return created
+
+
+def list_agreement_gaps(
+    session: Session, status: GapStatus | None = None
+) -> list[AgreementGap]:
+    query = select(AgreementGap).order_by(AgreementGap.confidence.desc(), AgreementGap.id.desc())
+    if status:
+        query = query.where(AgreementGap.status == status)
+    return list(session.execute(query).scalars())

--- a/job_scraper/kois/repository.py
+++ b/job_scraper/kois/repository.py
@@ -21,6 +21,10 @@ from job_scraper.kois.schema import (
 )
 from job_scraper.kois.utils import content_hash
 
+AGREEMENT_GAP_AUTO_CLOSE_NOTE = (
+    "Auto-closed after matching agreement signal detected for this buyer."
+)
+
 AUTOMATED_REVIEW_STATUSES = frozenset(
     {ReviewStatus.AUTO_ACCEPTED, ReviewStatus.NEEDS_REVIEW}
 )
@@ -351,6 +355,13 @@ def upsert_agreement_gap(session: Session, payload: dict) -> AgreementGap:
         existing.evidence_json = payload["evidence_json"]
         if existing.status == GapStatus.OPEN:
             existing.status = payload.get("status", GapStatus.OPEN)
+        elif (
+            existing.status == GapStatus.IGNORED
+            and existing.note == AGREEMENT_GAP_AUTO_CLOSE_NOTE
+        ):
+            existing.status = payload.get("status", GapStatus.OPEN)
+            if existing.status == GapStatus.OPEN:
+                existing.note = None
         session.flush()
         return existing
 

--- a/job_scraper/kois/repository.py
+++ b/job_scraper/kois/repository.py
@@ -330,6 +330,22 @@ def upsert_agreement_signal(session: Session, payload: dict) -> AgreementSignal:
     return created
 
 
+def delete_agreement_signal(
+    session: Session, *, source_name: str, external_id: str
+) -> bool:
+    existing = session.execute(
+        select(AgreementSignal).where(
+            AgreementSignal.source_name == source_name,
+            AgreementSignal.external_id == external_id,
+        )
+    ).scalar_one_or_none()
+    if existing is None:
+        return False
+    session.delete(existing)
+    session.flush()
+    return True
+
+
 def list_agreement_signals(
     session: Session,
     buyer_name: str | None = None,

--- a/job_scraper/kois/review_api.py
+++ b/job_scraper/kois/review_api.py
@@ -5,15 +5,24 @@ from pydantic import BaseModel
 from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
 
+from job_scraper.kois.analytics import phase2_summary
 from job_scraper.kois.db import get_db_session
+from job_scraper.kois.gaps import discover_missing_agreement_gaps, set_gap_status
+from job_scraper.kois.repository import list_agreement_gaps, list_agreement_signals
 from job_scraper.kois.review import ReviewService
-from job_scraper.kois.schema import OpportunityCluster, ReviewStatus
+from job_scraper.kois.schema import GapStatus, OpportunityCluster, ReviewStatus
 
-app = FastAPI(title="KOIS Phase 1 Review API")
+app = FastAPI(title="KOIS Phase 2 Review And Intelligence API")
 
 
 class ReviewUpdate(BaseModel):
     status: ReviewStatus
+    actor: str = "reviewer"
+    note: str | None = None
+
+
+class GapStatusUpdate(BaseModel):
+    status: GapStatus
     actor: str = "reviewer"
     note: str | None = None
 
@@ -95,3 +104,91 @@ def update_cluster_status(
         "id": cluster.id,
         "status": cluster.review_status.value,
     }
+
+
+@app.get("/analytics/summary")
+def analytics_summary(session: Session = Depends(get_db_session)):
+    return phase2_summary(session)
+
+
+@app.get("/agreement-signals")
+def agreement_signals(
+    buyer: str | None = None,
+    agreement_type: str | None = None,
+    limit: int = 50,
+    session: Session = Depends(get_db_session),
+):
+    signals = list_agreement_signals(
+        session=session,
+        buyer_name=buyer,
+        agreement_type=agreement_type,
+        limit=limit,
+    )
+    return [
+        {
+            "id": signal.id,
+            "source_name": signal.source_name,
+            "external_id": signal.external_id,
+            "title": signal.title,
+            "buyer_name": signal.buyer_name,
+            "agreement_type": signal.agreement_type,
+            "category": signal.category,
+            "status": signal.status,
+            "source_url": signal.source_url,
+            "confidence": signal.signal_confidence,
+        }
+        for signal in signals
+    ]
+
+
+@app.post("/agreement-gaps/discover")
+def discover_agreement_gaps(
+    min_cluster_hits: int = 2,
+    session: Session = Depends(get_db_session),
+):
+    gaps = discover_missing_agreement_gaps(
+        session=session, min_cluster_hits=min_cluster_hits
+    )
+    session.commit()
+    return {"discovered": len(gaps)}
+
+
+@app.get("/agreement-gaps")
+def agreement_gaps(
+    status: GapStatus | None = None,
+    session: Session = Depends(get_db_session),
+):
+    gaps = list_agreement_gaps(session=session, status=status)
+    return [
+        {
+            "id": gap.id,
+            "gap_key": gap.gap_key,
+            "buyer_name": gap.buyer_name,
+            "status": gap.status.value,
+            "confidence": gap.confidence,
+            "rationale": gap.rationale,
+            "evidence": gap.evidence_json,
+            "note": gap.note,
+        }
+        for gap in gaps
+    ]
+
+
+@app.patch("/agreement-gaps/{gap_id}/status")
+def update_agreement_gap_status(
+    gap_id: int,
+    update: GapStatusUpdate,
+    session: Session = Depends(get_db_session),
+):
+    try:
+        gap = set_gap_status(
+            session=session,
+            gap_id=gap_id,
+            status=update.status,
+            actor=update.actor,
+            note=update.note,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    session.commit()
+    return {"id": gap.id, "status": gap.status.value}

--- a/job_scraper/kois/schema.py
+++ b/job_scraper/kois/schema.py
@@ -19,6 +19,13 @@ class ReviewStatus(str, enum.Enum):
     WATCH_ONLY = "watch_only"
 
 
+class GapStatus(str, enum.Enum):
+    OPEN = "open"
+    ACKNOWLEDGED = "acknowledged"
+    WATCH_ONLY = "watch_only"
+    IGNORED = "ignored"
+
+
 class RawSourceItem(Base):
     __tablename__ = "raw_source_items"
     __table_args__ = (
@@ -188,3 +195,63 @@ class DigestItem(Base):
     )
 
     cluster: Mapped[OpportunityCluster] = relationship(back_populates="digest_items")
+
+
+class AgreementSignal(Base):
+    __tablename__ = "agreement_signals"
+    __table_args__ = (
+        UniqueConstraint(
+            "source_name",
+            "external_id",
+            name="uq_agreement_signal_source_external",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    raw_source_item_id: Mapped[int] = mapped_column(
+        ForeignKey("raw_source_items.id"), index=True
+    )
+    source_name: Mapped[str] = mapped_column(String(128), index=True)
+    external_id: Mapped[str] = mapped_column(String(512), index=True)
+    title: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
+    buyer_name: Mapped[Optional[str]] = mapped_column(String(256), nullable=True, index=True)
+    agreement_type: Mapped[Optional[str]] = mapped_column(String(64), nullable=True, index=True)
+    category: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    status: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    source_url: Mapped[Optional[str]] = mapped_column(String(1024), nullable=True)
+    published_at: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    deadline: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    signal_confidence: Mapped[float] = mapped_column(default=0.0)
+    metadata_json: Mapped[dict] = mapped_column("metadata", JSON, default=dict)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    raw_source: Mapped[RawSourceItem] = relationship()
+
+
+class AgreementGap(Base):
+    __tablename__ = "agreement_gaps"
+    __table_args__ = (
+        UniqueConstraint("gap_key", name="uq_agreement_gap_key"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    gap_key: Mapped[str] = mapped_column(String(256), index=True)
+    buyer_name: Mapped[str] = mapped_column(String(256), index=True)
+    status: Mapped[GapStatus] = mapped_column(
+        Enum(GapStatus), default=GapStatus.OPEN, index=True
+    )
+    confidence: Mapped[float] = mapped_column(default=0.0)
+    rationale: Mapped[str] = mapped_column(Text, default="")
+    evidence_json: Mapped[dict] = mapped_column("evidence", JSON, default=dict)
+    note: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow
+    )

--- a/tests/test_phase2_intelligence.py
+++ b/tests/test_phase2_intelligence.py
@@ -243,3 +243,42 @@ def test_infer_source_kind_does_not_promote_generic_tender_scrapers():
         metadata={"platform": "Talent Tender Board"},
     )
     assert source_kind == SourceKind.BROKER
+
+
+def test_agreement_signal_detects_compact_agreement_type_values():
+    session = _session()
+    raw = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="procurement",
+            source_name="feed",
+            external_id="compact-1",
+            raw_body='{"id":"compact-1"}',
+            metadata={
+                "notice_payload": {
+                    "title": "Cloud operations procurement",
+                    "buyer": "Oslo kommune",
+                    "agreement_type": "frame",
+                }
+            },
+        ),
+    )
+    record = create_extracted_record(
+        session,
+        {
+            "raw_source_item_id": raw.id,
+            "title": "Cloud operations procurement",
+            "customer": "Oslo kommune",
+            "broker": "feed",
+            "source_url": "https://example.com/compact-1",
+            "deadline": None,
+            "description": "procurement notice",
+            "summary": None,
+            "extraction_confidence": 0.8,
+            "extracted_data": {"agreement_type": "frame", "source_kind": "public_tender"},
+        },
+    )
+
+    payload = build_agreement_signal_payload(raw_item=raw, record=record)
+    assert payload is not None
+    assert payload["agreement_type"] == "frame"

--- a/tests/test_phase2_intelligence.py
+++ b/tests/test_phase2_intelligence.py
@@ -302,6 +302,74 @@ def test_agreement_signal_detection_ignores_non_procurement_framework_mentions()
     assert payload is None
 
 
+def test_source_kind_priority_prefers_email_over_forward_like_scraper():
+    session = _session()
+    raw_email = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="email",
+            source_name="oppdrag@kynd.no",
+            external_id="mail-forward-1",
+            raw_body="email-content",
+        ),
+    )
+    raw_forward_scraper = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="scraper",
+            source_name="forward-talent",
+            external_id="forward-1",
+            raw_body="forwarded-summary",
+        ),
+    )
+    email_record = create_extracted_record(
+        session,
+        {
+            "raw_source_item_id": raw_email.id,
+            "title": "Backend engineer",
+            "customer": "Kynd",
+            "broker": "sender@example.com",
+            "source_url": "https://example.com/shared",
+            "deadline": "2026-07-01",
+            "description": "email body",
+            "summary": None,
+            "extraction_confidence": 0.8,
+            "extracted_data": {"source_kind": "email_forwarded"},
+        },
+    )
+    forward_scraper_record = create_extracted_record(
+        session,
+        {
+            "raw_source_item_id": raw_forward_scraper.id,
+            "title": "Backend engineer",
+            "customer": "Kynd",
+            "broker": "Forward Talent",
+            "source_url": "https://forward.example.com/shared",
+            "deadline": "2026-07-01",
+            "description": "forwarded broker summary",
+            "summary": None,
+            "extraction_confidence": 0.9,
+            "extracted_data": {
+                "source_kind": "forwarded",
+                "source_type": "scraper",
+                "platform": "Forward Talent",
+            },
+        },
+    )
+    clusters = cluster_records(session, [forward_scraper_record, email_record])
+    session.commit()
+    assert clusters[-1].primary_source_record_id == email_record.id
+
+
+def test_infer_source_kind_classifies_forward_like_scrapers_below_broker():
+    source_kind = infer_source_kind(
+        source_type="scraper",
+        source_name="forward-talent",
+        metadata={"platform": "Forward Talent"},
+    )
+    assert source_kind == SourceKind.FORWARDED
+
+
 def test_infer_source_kind_does_not_promote_generic_tender_scrapers():
     source_kind = infer_source_kind(
         source_type="scraper",

--- a/tests/test_phase2_intelligence.py
+++ b/tests/test_phase2_intelligence.py
@@ -1,0 +1,167 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from job_scraper.kois.analytics import phase2_summary
+from job_scraper.kois.db import Base
+from job_scraper.kois.extraction import RecordExtractor
+from job_scraper.kois.gaps import discover_missing_agreement_gaps
+from job_scraper.kois.ingestion.procurement_adapter import fetch_procurement_items
+from job_scraper.kois.config import KOISSettings
+from job_scraper.kois.repository import (
+    create_extracted_record,
+    list_agreement_gaps,
+    upsert_agreement_signal,
+    upsert_raw_source_item,
+)
+from job_scraper.kois import review_api
+from job_scraper.kois.schema import GapStatus
+from job_scraper.kois.clustering import cluster_records
+from job_scraper.kois.domain import RawIngestionItem
+
+
+def _session() -> Session:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    return Session(bind=engine, future=True)
+
+
+def test_procurement_adapter_reads_embedded_feeds():
+    settings = KOISSettings(
+        doffin_feed_json='[{"id":"n-1","title":"DPS Cloud","buyer":"Oslo","agreement_type":"dps"}]',
+        procurement_feed_json_by_source={
+            "anskaffelser": '[{"id":"n-2","title":"Frame Python","buyer":"Bergen","agreement_type":"frame"}]'
+        },
+    )
+    items = fetch_procurement_items(settings)
+    assert len(items) == 2
+    assert {item.source_name for item in items} == {"doffin", "anskaffelser"}
+    assert all(item.source_type == "procurement" for item in items)
+
+
+def test_source_kind_priority_prefers_public_tender():
+    session = _session()
+    raw_public = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="procurement",
+            source_name="doffin",
+            external_id="d-1",
+            raw_body='{"id":"d-1"}',
+            metadata={
+                "notice_payload": {
+                    "id": "d-1",
+                    "title": "Senior Python",
+                    "buyer": "Kynd",
+                    "url": "https://example.com/opportunity",
+                }
+            },
+        ),
+    )
+    raw_broker = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="scraper",
+            source_name="mercell",
+            external_id="m-1",
+            raw_body='{"id":"m-1"}',
+        ),
+    )
+    public_record = create_extracted_record(
+        session,
+        {
+            "raw_source_item_id": raw_public.id,
+            "title": "Senior Python",
+            "customer": "Kynd",
+            "broker": "Doffin",
+            "source_url": "https://example.com/opportunity",
+            "deadline": "2026-07-01",
+            "description": "public notice",
+            "summary": None,
+            "extraction_confidence": 0.9,
+            "extracted_data": {"source_kind": "public_tender"},
+        },
+    )
+    broker_record = create_extracted_record(
+        session,
+        {
+            "raw_source_item_id": raw_broker.id,
+            "title": "Senior Python",
+            "customer": "Kynd",
+            "broker": "Mercell",
+            "source_url": "https://example.com/opportunity",
+            "deadline": "2026-07-01",
+            "description": "broker summary",
+            "summary": None,
+            "extraction_confidence": 0.9,
+            "extracted_data": {"source_kind": "broker"},
+        },
+    )
+    clusters = cluster_records(session, [broker_record, public_record])
+    session.commit()
+    assert clusters[-1].primary_source_record_id == public_record.id
+
+
+def test_agreement_gap_discovery_and_api():
+    session = _session()
+    raw = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="procurement",
+            source_name="doffin",
+            external_id="notice-1",
+            raw_body='{"id":"notice-1"}',
+            metadata={"notice_payload": {"title": "DPS backend", "buyer": "Oslo kommune"}},
+        ),
+    )
+    record = RecordExtractor().extract(raw)
+    extracted = create_extracted_record(session, record)
+    cluster_records(session, [extracted, extracted])
+    session.commit()
+
+    discover_missing_agreement_gaps(session, min_cluster_hits=1)
+    session.commit()
+    gaps = list_agreement_gaps(session)
+    assert len(gaps) == 1
+    assert gaps[0].status == GapStatus.OPEN
+
+    upsert_agreement_signal(
+        session,
+        {
+            "raw_source_item_id": raw.id,
+            "source_name": "doffin",
+            "external_id": "notice-1",
+            "title": "DPS backend",
+            "buyer_name": "Oslo kommune",
+            "agreement_type": "dps",
+            "category": "it",
+            "status": "open",
+            "source_url": "https://example.com/n/1",
+            "published_at": None,
+            "deadline": None,
+            "signal_confidence": 0.8,
+            "metadata_json": {},
+        },
+    )
+    session.commit()
+
+    summary = review_api.analytics_summary(session)
+    assert "coverage" in summary
+
+    gaps_response = review_api.agreement_gaps(status=None, session=session)
+    assert len(gaps_response) >= 1
+
+    patch_response = review_api.update_agreement_gap_status(
+        gap_id=gaps[0].id,
+        update=review_api.GapStatusUpdate(
+            status=GapStatus.WATCH_ONLY,
+            actor="tester",
+            note="monitor",
+        ),
+        session=session,
+    )
+    assert patch_response["status"] == "watch_only"
+
+
+def test_phase2_summary_contract():
+    session = _session()
+    summary = phase2_summary(session)
+    assert set(summary) == {"buyer_trends", "broker_patterns", "source_quality", "coverage"}

--- a/tests/test_phase2_intelligence.py
+++ b/tests/test_phase2_intelligence.py
@@ -1,5 +1,6 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
+from job_scraper.kois.agreement_signals import build_agreement_signal_payload
 from job_scraper.kois.analytics import phase2_summary
 from job_scraper.kois.db import Base
 from job_scraper.kois.extraction import RecordExtractor
@@ -9,13 +10,14 @@ from job_scraper.kois.config import KOISSettings
 from job_scraper.kois.repository import (
     create_extracted_record,
     list_agreement_gaps,
+    upsert_agreement_gap,
     upsert_agreement_signal,
     upsert_raw_source_item,
 )
 from job_scraper.kois import review_api
 from job_scraper.kois.schema import GapStatus
 from job_scraper.kois.clustering import cluster_records
-from job_scraper.kois.domain import RawIngestionItem
+from job_scraper.kois.domain import RawIngestionItem, SourceKind, infer_source_kind
 
 
 def _session() -> Session:
@@ -143,11 +145,16 @@ def test_agreement_gap_discovery_and_api():
     )
     session.commit()
 
+    discover_missing_agreement_gaps(session, min_cluster_hits=1)
+    session.commit()
+
     summary = review_api.analytics_summary(session)
     assert "coverage" in summary
+    assert summary["coverage"]["open_gap_count"] == 0
 
     gaps_response = review_api.agreement_gaps(status=None, session=session)
     assert len(gaps_response) >= 1
+    assert gaps_response[0]["status"] == GapStatus.IGNORED.value
 
     patch_response = review_api.update_agreement_gap_status(
         gap_id=gaps[0].id,
@@ -165,3 +172,74 @@ def test_phase2_summary_contract():
     session = _session()
     summary = phase2_summary(session)
     assert set(summary) == {"buyer_trends", "broker_patterns", "source_quality", "coverage"}
+
+
+def test_gap_upsert_preserves_acknowledged_status():
+    session = _session()
+    created = upsert_agreement_gap(
+        session,
+        {
+            "gap_key": "buyer:oslo",
+            "buyer_name": "Oslo kommune",
+            "status": GapStatus.OPEN,
+            "confidence": 0.6,
+            "rationale": "initial",
+            "evidence_json": {"cluster_count": 2},
+        },
+    )
+    created.status = GapStatus.ACKNOWLEDGED
+    session.flush()
+
+    updated = upsert_agreement_gap(
+        session,
+        {
+            "gap_key": "buyer:oslo",
+            "buyer_name": "Oslo kommune",
+            "status": GapStatus.OPEN,
+            "confidence": 0.8,
+            "rationale": "updated",
+            "evidence_json": {"cluster_count": 3},
+        },
+    )
+    assert updated.status == GapStatus.ACKNOWLEDGED
+
+
+def test_agreement_signal_detection_ignores_non_procurement_framework_mentions():
+    session = _session()
+    raw = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="scraper",
+            source_name="broker-feed",
+            external_id="s-1",
+            raw_body="framework-heavy assignment",
+            metadata={},
+        ),
+    )
+    record = create_extracted_record(
+        session,
+        {
+            "raw_source_item_id": raw.id,
+            "title": "Senior engineer assignment",
+            "customer": "City",
+            "broker": "Broker",
+            "source_url": "https://example.com/s-1",
+            "deadline": None,
+            "description": "Requires deep experience in framework migration work.",
+            "summary": None,
+            "extraction_confidence": 0.7,
+            "extracted_data": {"source_kind": "broker"},
+        },
+    )
+
+    payload = build_agreement_signal_payload(raw_item=raw, record=record)
+    assert payload is None
+
+
+def test_infer_source_kind_does_not_promote_generic_tender_scrapers():
+    source_kind = infer_source_kind(
+        source_type="scraper",
+        source_name="tender-hub-broker",
+        metadata={"platform": "Talent Tender Board"},
+    )
+    assert source_kind == SourceKind.BROKER

--- a/tests/test_phase2_intelligence.py
+++ b/tests/test_phase2_intelligence.py
@@ -4,7 +4,7 @@ from job_scraper.kois.agreement_signals import build_agreement_signal_payload
 from job_scraper.kois.analytics import phase2_summary
 from job_scraper.kois.db import Base
 from job_scraper.kois.extraction import RecordExtractor
-from job_scraper.kois.gaps import discover_missing_agreement_gaps
+from job_scraper.kois.gaps import discover_missing_agreement_gaps, set_gap_status
 from job_scraper.kois.ingestion.procurement_adapter import fetch_procurement_items
 from job_scraper.kois.config import KOISSettings
 from job_scraper.kois.repository import (
@@ -282,3 +282,30 @@ def test_agreement_signal_detects_compact_agreement_type_values():
     payload = build_agreement_signal_payload(raw_item=raw, record=record)
     assert payload is not None
     assert payload["agreement_type"] == "frame"
+
+
+def test_set_gap_status_preserves_existing_note_when_note_is_omitted():
+    session = _session()
+    gap = upsert_agreement_gap(
+        session,
+        {
+            "gap_key": "buyer:trondheim",
+            "buyer_name": "Trondheim kommune",
+            "status": GapStatus.OPEN,
+            "confidence": 0.7,
+            "rationale": "Repeated demand",
+            "evidence_json": {"cluster_count": 2},
+        },
+    )
+    gap.note = "Needs legal validation"
+    session.flush()
+
+    updated = set_gap_status(
+        session=session,
+        gap_id=gap.id,
+        status=GapStatus.ACKNOWLEDGED,
+        actor="tester",
+        note=None,
+    )
+    assert updated.status == GapStatus.ACKNOWLEDGED
+    assert updated.note == "Needs legal validation"

--- a/tests/test_phase2_intelligence.py
+++ b/tests/test_phase2_intelligence.py
@@ -8,6 +8,7 @@ from job_scraper.kois.gaps import discover_missing_agreement_gaps, set_gap_statu
 from job_scraper.kois.ingestion.procurement_adapter import fetch_procurement_items
 from job_scraper.kois.config import KOISSettings
 from job_scraper.kois.repository import (
+    AGREEMENT_GAP_AUTO_CLOSE_NOTE,
     create_extracted_record,
     detach_record_cluster_sources,
     list_agreement_gaps,
@@ -173,6 +174,70 @@ def test_phase2_summary_contract():
     session = _session()
     summary = phase2_summary(session)
     assert set(summary) == {"buyer_trends", "broker_patterns", "source_quality", "coverage"}
+
+
+def test_gap_upsert_reopens_auto_closed_gap_when_coverage_missing_again():
+    session = _session()
+    gap = upsert_agreement_gap(
+        session,
+        {
+            "gap_key": "buyer:bergen",
+            "buyer_name": "Bergen kommune",
+            "status": GapStatus.OPEN,
+            "confidence": 0.7,
+            "rationale": "Repeated demand",
+            "evidence_json": {"cluster_count": 2},
+        },
+    )
+    gap.status = GapStatus.IGNORED
+    gap.note = AGREEMENT_GAP_AUTO_CLOSE_NOTE
+    session.flush()
+
+    reopened = upsert_agreement_gap(
+        session,
+        {
+            "gap_key": "buyer:bergen",
+            "buyer_name": "Bergen kommune",
+            "status": GapStatus.OPEN,
+            "confidence": 0.8,
+            "rationale": "Repeated demand",
+            "evidence_json": {"cluster_count": 3},
+        },
+    )
+    assert reopened.status == GapStatus.OPEN
+    assert reopened.note is None
+
+
+def test_gap_upsert_preserves_user_ignored_status():
+    session = _session()
+    gap = upsert_agreement_gap(
+        session,
+        {
+            "gap_key": "buyer:stavanger",
+            "buyer_name": "Stavanger kommune",
+            "status": GapStatus.OPEN,
+            "confidence": 0.7,
+            "rationale": "Repeated demand",
+            "evidence_json": {"cluster_count": 2},
+        },
+    )
+    gap.status = GapStatus.IGNORED
+    gap.note = "Not actionable for this quarter."
+    session.flush()
+
+    updated = upsert_agreement_gap(
+        session,
+        {
+            "gap_key": "buyer:stavanger",
+            "buyer_name": "Stavanger kommune",
+            "status": GapStatus.OPEN,
+            "confidence": 0.8,
+            "rationale": "Repeated demand",
+            "evidence_json": {"cluster_count": 3},
+        },
+    )
+    assert updated.status == GapStatus.IGNORED
+    assert updated.note == "Not actionable for this quarter."
 
 
 def test_gap_upsert_preserves_acknowledged_status():

--- a/tests/test_phase2_intelligence.py
+++ b/tests/test_phase2_intelligence.py
@@ -1,6 +1,9 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
-from job_scraper.kois.agreement_signals import build_agreement_signal_payload
+from job_scraper.kois.agreement_signals import (
+    build_agreement_signal_payload,
+    sync_procurement_agreement_signal,
+)
 from job_scraper.kois.analytics import phase2_summary
 from job_scraper.kois.db import Base
 from job_scraper.kois.extraction import RecordExtractor
@@ -12,6 +15,7 @@ from job_scraper.kois.repository import (
     create_extracted_record,
     detach_record_cluster_sources,
     list_agreement_gaps,
+    list_agreement_signals,
     upsert_agreement_gap,
     upsert_agreement_signal,
     upsert_raw_source_item,
@@ -377,6 +381,76 @@ def test_infer_source_kind_does_not_promote_generic_tender_scrapers():
         metadata={"platform": "Talent Tender Board"},
     )
     assert source_kind == SourceKind.BROKER
+
+
+def test_sync_procurement_agreement_signal_revokes_stale_signal_and_reopens_gap():
+    session = _session()
+    raw = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="procurement",
+            source_name="doffin",
+            external_id="notice-revoke-1",
+            raw_body='{"id":"notice-revoke-1"}',
+            metadata={
+                "notice_payload": {
+                    "title": "DPS backend",
+                    "buyer": "Oslo kommune",
+                    "agreement_type": "dps",
+                }
+            },
+        ),
+    )
+    record = create_extracted_record(
+        session,
+        RecordExtractor().extract(raw),
+    )
+    cluster_records(session, [record, record])
+    session.commit()
+
+    discover_missing_agreement_gaps(session, min_cluster_hits=1)
+    session.commit()
+    gaps = list_agreement_gaps(session)
+    assert len(gaps) == 1
+    assert gaps[0].status == GapStatus.OPEN
+
+    sync_procurement_agreement_signal(session, raw_item=raw, record=record)
+    session.commit()
+    assert len(list_agreement_signals(session)) == 1
+
+    discover_missing_agreement_gaps(session, min_cluster_hits=1)
+    session.commit()
+    gaps = list_agreement_gaps(session)
+    assert gaps[0].status == GapStatus.IGNORED
+    assert gaps[0].note == AGREEMENT_GAP_AUTO_CLOSE_NOTE
+
+    raw.metadata_json = {
+        "notice_payload": {
+            "title": "Backend consultant assignment",
+            "buyer": "Oslo kommune",
+            "agreement_type": "open_competition",
+        }
+    }
+    record.title = "Backend consultant assignment"
+    record.extracted_data = {
+        **(record.extracted_data or {}),
+        "agreement_type": "open_competition",
+    }
+    session.flush()
+
+    sync_procurement_agreement_signal(session, raw_item=raw, record=record)
+    session.commit()
+    assert list_agreement_signals(session) == []
+
+    discover_missing_agreement_gaps(session, min_cluster_hits=1)
+    session.commit()
+    reopened = list_agreement_gaps(session)[0]
+    assert reopened.status == GapStatus.OPEN
+    assert reopened.note is None
+
+    summary = phase2_summary(session)
+    assert summary["coverage"]["agreement_signal_count"] == 0
+    assert summary["coverage"]["open_gap_count"] == 1
 
 
 def test_agreement_signal_detects_compact_agreement_type_values():

--- a/tests/test_phase2_intelligence.py
+++ b/tests/test_phase2_intelligence.py
@@ -9,6 +9,7 @@ from job_scraper.kois.ingestion.procurement_adapter import fetch_procurement_ite
 from job_scraper.kois.config import KOISSettings
 from job_scraper.kois.repository import (
     create_extracted_record,
+    detach_record_cluster_sources,
     list_agreement_gaps,
     upsert_agreement_gap,
     upsert_agreement_signal,
@@ -309,3 +310,39 @@ def test_set_gap_status_preserves_existing_note_when_note_is_omitted():
     )
     assert updated.status == GapStatus.ACKNOWLEDGED
     assert updated.note == "Needs legal validation"
+
+
+def test_gap_discovery_ignores_clusters_without_attached_sources():
+    session = _session()
+    raw = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="scraper",
+            source_name="broker-feed",
+            external_id="orphan-1",
+            raw_body='{"id":"orphan-1"}',
+        ),
+    )
+    record = create_extracted_record(
+        session,
+        {
+            "raw_source_item_id": raw.id,
+            "title": "Senior engineer",
+            "customer": "Oslo kommune",
+            "broker": "Broker",
+            "source_url": "https://example.com/orphan-1",
+            "deadline": None,
+            "description": "broker assignment",
+            "summary": None,
+            "extraction_confidence": 0.8,
+            "extracted_data": {"source_kind": "broker"},
+        },
+    )
+    clusters = cluster_records(session, [record])
+    assert len(clusters) == 1
+
+    detach_record_cluster_sources(session, record)
+    session.flush()
+
+    discovered = discover_missing_agreement_gaps(session, min_cluster_hits=1)
+    assert discovered == []


### PR DESCRIPTION
## Summary
- implement canonical source taxonomy and refactor primary-source ranking to use normalized source-kind metadata across extraction, clustering, and analytics paths
- add Phase 2 procurement ingestion (Doffin + configurable procurement feeds), persisted `AgreementSignal`/`AgreementGap` models, and migration support for additive rollout
- add Phase 2 market intelligence services and API endpoints for analytics summary, agreement signal listing, and missing-agreement discovery/triage, with focused test coverage and PID sync

## Test plan
- [x] `python3 -m ruff check .`
- [x] `python3 -m pytest`
- [x] verify new tests for procurement adapter, source-priority regression, agreement gap workflow, and analytics contract in `tests/test_phase2_intelligence.py`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches clustering primary-source selection, runs new external feed fetches, and adds DB tables/migration; behavior is covered by extensive tests but feed URL failures are swallowed silently in the adapter.
> 
> **Overview**
> Adds **KOIS Phase 2** market and agreement intelligence on top of the existing inbox pipeline.
> 
> **Ingestion and extraction:** Procurement notices are loaded via a new adapter (embedded JSON or URLs for Doffin and per-source feeds), wired into `run_kois_pipeline`. Records from `procurement` sources get a dedicated extractor path with notice metadata (agreement/notice type, category).
> 
> **Source ranking:** Introduces a canonical `source_kind` taxonomy (`public_tender`, `procurement_platform`, `email_forwarded`, etc.) via `infer_source_kind`, stored on extracted records and used for primary-source priority in clustering (replacing older `doffin`/`procurement`/`email` keys).
> 
> **Agreement signals and gaps:** Persists `AgreementSignal` rows for procurement notices that look like DPS/frame agreements (phrase matching on type/title; non-procurement sources ignored). Sync upserts or deletes signals when notices change. `AgreementGap` records flag buyers with repeated clustered demand but no agreement signal; discovery runs in the pipeline (configurable `min_cluster_hits`), auto-closes gaps when a buyer gains a signal, and respects manual gap statuses on re-upsert.
> 
> **API and analytics:** Review API expands with `/analytics/summary`, agreement signal listing, gap list/discover, and gap status PATCH. Analytics aggregates buyer/broker trends, source conflict stats, and agreement coverage counts.
> 
> **Schema:** Additive migration creates `agreement_signals` and `agreement_gaps` tables; PID updated for `AgreementGap` and Phase 2 status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f07ee5eaa081e825fe7463a9dff9f29719ea3745. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->