### PR TITLE
Implement KOIS Phase 3 sales opportunity filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ jobs.json
 __pycache__/
 .pytest_cache/
 .ruff_cache/
+.venv/

--- a/PID.md
+++ b/PID.md
@@ -53,6 +53,9 @@ KOIS does not own:
 - `AgreementGap`: persisted potential coverage gap where repeated buyer demand appears without matching agreement signals.
 - `ReviewState`: `auto_accepted`, `needs_review`, `manually_merged`, `manually_split`, `ignored`, or `watch_only`.
 - `DigestItem`: generated output for Slack or reports, backed by stored evidence.
+- `RoleClassification`: lightweight role category and tags inferred from cluster source content.
+- `RelevanceScore`: availability-aware score used for sales filtering and digest eligibility.
+- `AvailabilityProfile`: lightweight operator-provided role capacity signal used for Phase 3 filtering.
 - `ExternalFitAssessment`: later KBS-provided fit assessment for consultants, CVs, references, or bid material.
 
 ## Source Priority
@@ -91,6 +94,8 @@ Add lightweight role classification, availability-aware digest modes, source/rel
 
 Success metric: Slack highlights fewer but better items while the archive remains complete.
 
+Implementation status: in progress. Current implementation adds deterministic role classification, availability-profile-aware relevance scoring, configurable digest thresholds/cadence, and relevant-opportunity API filtering while preserving archive recall.
+
 ### Phase 4: KBS Integration
 
 Expose opportunity profiles to KBS and receive high-level fit assessments back. KOIS should not own CV or bid material.
@@ -107,6 +112,7 @@ Success metric: recruitment and CV positioning decisions are informed by observe
 
 - Basic UI for review, merge, split, ignore, and source comparison.
 - Slack channels for conservative digests, review prompts, and optionally DPS/agreement updates.
+- API view for relevance-filtered opportunities based on current Phase 3 policy.
 - Periodic market reports.
 - Searchable archive.
 - API or export surface for KBS.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-## KOIS Phase 1 Foundation
+## KOIS Phases 1-3
 
-This repository now implements the KOIS Phase 1 foundation: provenance-first ingestion and clustering of assignment opportunities from broker scrapers and `oppdrag@kynd.no` (IMAP), with conservative Slack digest output backed by stored evidence.
+This repository implements KOIS as a provenance-first opportunity intelligence pipeline:
+- Phase 1 foundation (ingestion, extraction, clustering, review states, digest persistence)
+- Phase 2 market intelligence (agreement signals, gap discovery, analytics endpoints)
+- Phase 3 sales filtering (role classification, availability-aware relevance scoring, configurable digest thresholds/cadence, relevant-opportunity API view)
 
 Per run pipeline:
 
@@ -9,7 +12,8 @@ Per run pipeline:
 3. persist immutable raw source evidence (`raw_source_items`)
 4. extract structured records (`extracted_records`)
 5. cluster likely duplicates with source comparisons (`opportunity_clusters`, `source_comparisons`)
-6. create review states (`review_states`) and conservative digest items (`digest_items`)
+6. classify cluster role fit + relevance against lightweight availability profile
+7. create review states (`review_states`) and conservative digest items (`digest_items`)
 
 ### Requirements
 
@@ -24,6 +28,12 @@ Core:
 - `DATABASE_URL` (example: `postgresql+psycopg://postgres:postgres@localhost:5432/kois`)
 - `RUN_LIVE_SLACK` (`false` by default; set `true` to post live)
 - `SLACK_CHANNEL` (`job-posting` default)
+- `DIGEST_MODE` (`balanced`, `high_precision`, `high_recall`)
+- `DIGEST_MIN_RELEVANCE_SCORE` (default `0.35`)
+- `DIGEST_MIN_SOURCE_CONFIDENCE` (default `0.75`)
+- `DIGEST_CADENCE_MINUTES` (default `0`, meaning no cadence gate)
+- `AVAILABILITY_PROFILE_JSON` (optional role capacity map, e.g. `{"data_engineering":2,"backend":1}`)
+- `ROLE_TAXONOMY_JSON` (optional role-to-keywords map to override defaults)
 
 Integrations:
 
@@ -46,7 +56,7 @@ IMAP (`oppdrag@kynd.no`):
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-pip install -e ".[dev]"
+pip install ".[dev]"
 python -m playwright install chromium
 ```
 
@@ -56,7 +66,7 @@ python -m playwright install chromium
 python -m job_scraper.main
 ```
 
-### Review API (basic queue/archive surface)
+### Review and Intelligence API
 
 ```bash
 uvicorn job_scraper.kois.review_api:app --reload
@@ -68,7 +78,12 @@ Useful endpoints:
 - `GET /clusters`
 - `GET /clusters?q=<search>`
 - `GET /review-queue`
+- `GET /opportunities/relevant`
 - `PATCH /clusters/{cluster_id}/status` with `auto_accepted`, `needs_review`, `manually_merged`, `manually_split`, `ignored`, `watch_only`
+- `GET /analytics/summary`
+- `GET /agreement-signals`
+- `GET /agreement-gaps`
+- `PATCH /agreement-gaps/{gap_id}/status`
 
 ### Checks
 
@@ -82,3 +97,4 @@ pytest
 - Raw evidence is preserved even when extraction fails.
 - Deduplication is cluster-based; source records are retained.
 - Slack digest output is driven by persisted cluster state, not transient scraper output.
+- Phase 3 filtering only affects presentation (digest/API relevance), not archive retention.

--- a/job_scraper/kois/config.py
+++ b/job_scraper/kois/config.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+from functools import cached_property
 from functools import lru_cache
 
 from pydantic import Field
@@ -32,9 +34,68 @@ class KOISSettings(BaseSettings):
     procurement_feed_json_by_source: dict[str, str] = Field(default_factory=dict)
     agreement_gap_min_cluster_hits: int = 2
 
+    digest_mode: str = "balanced"
+    digest_min_relevance_score: float = 0.35
+    digest_min_source_confidence: float = 0.75
+    digest_cadence_minutes: int = 0
+    availability_profile_json: str | None = None
+    role_taxonomy_json: str | None = None
+
     run_live_slack: bool = False
+
+    @cached_property
+    def availability_profile(self) -> dict[str, int]:
+        if not self.availability_profile_json:
+            return {}
+        return _parse_int_mapping_json(
+            self.availability_profile_json, field_name="availability_profile_json"
+        )
+
+    @cached_property
+    def role_taxonomy(self) -> dict[str, list[str]]:
+        if not self.role_taxonomy_json:
+            return {}
+        return _parse_role_taxonomy_json(self.role_taxonomy_json)
 
 
 @lru_cache(maxsize=1)
 def get_settings() -> KOISSettings:
     return KOISSettings()
+
+
+def _parse_int_mapping_json(raw_value: str, *, field_name: str) -> dict[str, int]:
+    try:
+        decoded = json.loads(raw_value)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{field_name} must be valid JSON: {exc}") from exc
+    if not isinstance(decoded, dict):
+        raise ValueError(f"{field_name} must decode to an object.")
+    parsed: dict[str, int] = {}
+    for key, value in decoded.items():
+        if not isinstance(key, str):
+            raise ValueError(f"{field_name} keys must be strings.")
+        if not isinstance(value, int):
+            raise ValueError(
+                f"{field_name}[{key!r}] must be an integer capacity value."
+            )
+        parsed[key.strip().lower()] = value
+    return parsed
+
+
+def _parse_role_taxonomy_json(raw_value: str) -> dict[str, list[str]]:
+    try:
+        decoded = json.loads(raw_value)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"role_taxonomy_json must be valid JSON: {exc}") from exc
+    if not isinstance(decoded, dict):
+        raise ValueError("role_taxonomy_json must decode to an object.")
+    parsed: dict[str, list[str]] = {}
+    for key, value in decoded.items():
+        if not isinstance(key, str):
+            raise ValueError("role_taxonomy_json keys must be strings.")
+        if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+            raise ValueError(
+                f"role_taxonomy_json[{key!r}] must be an array of strings."
+            )
+        parsed[key.strip().lower()] = [item.strip().lower() for item in value if item.strip()]
+    return parsed

--- a/job_scraper/kois/config.py
+++ b/job_scraper/kois/config.py
@@ -74,7 +74,7 @@ def _parse_int_mapping_json(raw_value: str, *, field_name: str) -> dict[str, int
     for key, value in decoded.items():
         if not isinstance(key, str):
             raise ValueError(f"{field_name} keys must be strings.")
-        if not isinstance(value, int):
+        if isinstance(value, bool) or not isinstance(value, int):
             raise ValueError(
                 f"{field_name}[{key!r}] must be an integer capacity value."
             )

--- a/job_scraper/kois/digest.py
+++ b/job_scraper/kois/digest.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from dataclasses import dataclass
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from job_scraper.kois.config import KOISSettings, get_settings
+from job_scraper.kois.filtering import OpportunityFilterPolicy
 from job_scraper.kois.repository import (
     create_digest_item,
     delete_unsent_digest_items,
     mark_digest_sent,
 )
-from job_scraper.kois.schema import OpportunityCluster, ReviewStatus
+from job_scraper.kois.schema import DigestItem, OpportunityCluster
 from job_scraper.slack_poster import SlackPoster
 
 
@@ -23,6 +27,10 @@ class DigestPayload:
     confidence: float
     review_status: str
     cluster_id: int
+    role_category: str | None
+    role_tags: list[str]
+    relevance_score: float
+    relevance_rationale: str | None
 
 
 def _resolve_primary_record(cluster: OpportunityCluster):
@@ -50,18 +58,39 @@ def cluster_to_payload(cluster: OpportunityCluster) -> DigestPayload:
         confidence=cluster.confidence,
         review_status=cluster.review_status.value,
         cluster_id=cluster.id,
+        role_category=cluster.role_category,
+        role_tags=cluster.role_tags_json or [],
+        relevance_score=cluster.relevance_score,
+        relevance_rationale=cluster.relevance_rationale,
     )
 
 
-def select_digest_candidates(clusters: list[OpportunityCluster]) -> list[OpportunityCluster]:
+def select_digest_candidates(
+    clusters: list[OpportunityCluster], policy: OpportunityFilterPolicy
+) -> list[OpportunityCluster]:
     candidates: list[OpportunityCluster] = []
     for cluster in clusters:
-        if cluster.review_status in (ReviewStatus.IGNORED, ReviewStatus.WATCH_ONLY):
-            continue
-        if cluster.review_status == ReviewStatus.NEEDS_REVIEW and cluster.confidence < 0.75:
+        if not policy.should_include_digest(cluster):
             continue
         candidates.append(cluster)
     return candidates
+
+
+def _cadence_blocked(session: Session, cadence_minutes: int) -> bool:
+    if cadence_minutes <= 0:
+        return False
+    latest_sent_at = session.execute(
+        select(DigestItem.sent_at)
+        .order_by(DigestItem.sent_at.desc())
+        .limit(1)
+    ).scalar_one_or_none()
+    if latest_sent_at is None:
+        return False
+    if latest_sent_at.tzinfo is None:
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+    else:
+        now = datetime.now(timezone.utc)
+    return latest_sent_at > (now - timedelta(minutes=cadence_minutes))
 
 
 def send_digest_items(
@@ -70,16 +99,23 @@ def send_digest_items(
     slack: SlackPoster,
     live_posting: bool,
     channel: str,
+    settings: KOISSettings | None = None,
+    policy: OpportunityFilterPolicy | None = None,
 ) -> list[dict]:
+    settings = settings or get_settings()
+    policy = policy or OpportunityFilterPolicy(settings)
+    cadence_minutes = int(getattr(settings, "digest_cadence_minutes", 0))
+    cadence_blocked = _cadence_blocked(session, cadence_minutes)
     sent_payloads: list[dict] = []
     for cluster in clusters:
+        evaluation = policy.apply_to_cluster(cluster)
         if not cluster.sources:
             delete_unsent_digest_items(session, cluster)
             continue
-        if cluster.review_status in (ReviewStatus.IGNORED, ReviewStatus.WATCH_ONLY):
+        if not policy.should_include_digest(
+            cluster, evaluated_relevance=evaluation.relevance_score
+        ):
             delete_unsent_digest_items(session, cluster)
-            continue
-        if cluster.review_status == ReviewStatus.NEEDS_REVIEW and cluster.confidence < 0.75:
             continue
 
         payload = cluster_to_payload(cluster)
@@ -90,6 +126,8 @@ def send_digest_items(
             payload=payload.__dict__,
         )
         if digest_item.sent_at is not None:
+            continue
+        if cadence_blocked:
             continue
 
         if live_posting:

--- a/job_scraper/kois/digest.py
+++ b/job_scraper/kois/digest.py
@@ -81,6 +81,7 @@ def _cadence_blocked(session: Session, cadence_minutes: int) -> bool:
         return False
     latest_sent_at = session.execute(
         select(DigestItem.sent_at)
+        .where(DigestItem.sent_at.is_not(None))
         .order_by(DigestItem.sent_at.desc())
         .limit(1)
     ).scalar_one_or_none()

--- a/job_scraper/kois/digest.py
+++ b/job_scraper/kois/digest.py
@@ -136,9 +136,7 @@ def send_digest_items(
             if response is None:
                 continue
             slack_ts = response.get("ts")
-        else:
-            slack_ts = None
+            mark_digest_sent(session, digest_item, slack_ts)
 
-        mark_digest_sent(session, digest_item, slack_ts)
         sent_payloads.append(payload.__dict__)
     return sent_payloads

--- a/job_scraper/kois/filtering.py
+++ b/job_scraper/kois/filtering.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy.orm import Session
+
+from job_scraper.kois.config import KOISSettings
+from job_scraper.kois.schema import OpportunityCluster, ReviewStatus
+from job_scraper.kois.utils import normalize_text
+
+
+DEFAULT_ROLE_TAXONOMY: dict[str, list[str]] = {
+    "data_engineering": [
+        "data engineer",
+        "data platform",
+        "etl",
+        "airflow",
+        "spark",
+        "dbt",
+        "pipeline",
+        "databricks",
+    ],
+    "backend": [
+        "backend",
+        "api",
+        "python",
+        "java",
+        "golang",
+        "microservice",
+        "fastapi",
+        "django",
+        "spring",
+    ],
+    "frontend": [
+        "frontend",
+        "react",
+        "typescript",
+        "javascript",
+        "angular",
+        "vue",
+        "ui",
+    ],
+    "cloud_devops": [
+        "devops",
+        "platform engineer",
+        "kubernetes",
+        "terraform",
+        "aws",
+        "azure",
+        "gcp",
+        "ci/cd",
+    ],
+    "security": [
+        "security",
+        "iam",
+        "soc",
+        "siem",
+        "zero trust",
+        "risk",
+        "compliance",
+    ],
+    "project_management": [
+        "project manager",
+        "scrum master",
+        "delivery lead",
+        "program manager",
+    ],
+    "qa_test": [
+        "qa",
+        "test automation",
+        "selenium",
+        "cypress",
+        "quality assurance",
+    ],
+}
+
+
+@dataclass(frozen=True)
+class ClusterFilteringResult:
+    role_category: str | None
+    role_tags: list[str]
+    relevance_score: float
+    relevance_rationale: str
+
+
+class OpportunityFilterPolicy:
+    def __init__(self, settings: KOISSettings):
+        self.settings = settings
+        taxonomy = getattr(settings, "role_taxonomy", None)
+        availability = getattr(settings, "availability_profile", None)
+        self.role_taxonomy = taxonomy or DEFAULT_ROLE_TAXONOMY
+        self.availability_profile = availability or {}
+        self.digest_mode = normalize_text(getattr(settings, "digest_mode", "balanced")) or "balanced"
+        self.min_relevance = float(getattr(settings, "digest_min_relevance_score", 0.35))
+        self.min_confidence = float(
+            getattr(settings, "digest_min_source_confidence", 0.75)
+        )
+
+    def evaluate_cluster(self, cluster: OpportunityCluster) -> ClusterFilteringResult:
+        role_category, role_tags = self._classify_cluster(cluster)
+        relevance_score, rationale = self._score_relevance(cluster, role_category)
+        return ClusterFilteringResult(
+            role_category=role_category,
+            role_tags=role_tags,
+            relevance_score=relevance_score,
+            relevance_rationale=rationale,
+        )
+
+    def apply_to_cluster(self, cluster: OpportunityCluster) -> ClusterFilteringResult:
+        result = self.evaluate_cluster(cluster)
+        cluster.role_category = result.role_category
+        cluster.role_tags_json = result.role_tags
+        cluster.relevance_score = result.relevance_score
+        cluster.relevance_rationale = result.relevance_rationale
+        return result
+
+    def should_include_digest(
+        self, cluster: OpportunityCluster, *, evaluated_relevance: float | None = None
+    ) -> bool:
+        if cluster.review_status in (ReviewStatus.IGNORED, ReviewStatus.WATCH_ONLY):
+            return False
+        if (
+            cluster.review_status == ReviewStatus.NEEDS_REVIEW
+            and cluster.confidence < self.min_confidence
+        ):
+            return False
+        relevance = (
+            evaluated_relevance
+            if evaluated_relevance is not None
+            else cluster.relevance_score
+        )
+        return relevance >= self.min_relevance
+
+    def _classify_cluster(self, cluster: OpportunityCluster) -> tuple[str | None, list[str]]:
+        haystack_parts = [cluster.title, cluster.customer]
+        for source in cluster.sources:
+            record = source.record
+            haystack_parts.extend(
+                [
+                    record.title,
+                    record.summary,
+                    record.description,
+                    record.broker,
+                    record.source_url,
+                ]
+            )
+        haystack = normalize_text(" ".join(part or "" for part in haystack_parts))
+        if not haystack:
+            return None, []
+
+        scores: dict[str, int] = {}
+        for role, keywords in self.role_taxonomy.items():
+            score = 0
+            for keyword in keywords:
+                normalized = normalize_text(keyword)
+                if normalized and normalized in haystack:
+                    score += 1
+            if score:
+                scores[role] = score
+
+        if not scores:
+            return "generalist", []
+        ranked = sorted(scores.items(), key=lambda item: (item[1], item[0]), reverse=True)
+        role_tags = [role for role, _ in ranked[:3]]
+        return ranked[0][0], role_tags
+
+    def _score_relevance(
+        self, cluster: OpportunityCluster, role_category: str | None
+    ) -> tuple[float, str]:
+        confidence_component = min(max(cluster.confidence, 0.0), 1.0) * 0.5
+        role_component = 0.2
+        capacity_component = 0.0
+        notes = [f"confidence={cluster.confidence:.2f}"]
+
+        if role_category and role_category in self.availability_profile:
+            capacity = self.availability_profile[role_category]
+            if capacity > 0:
+                capacity_component = min(0.4, 0.1 + (capacity * 0.06))
+                notes.append(f"capacity={capacity}")
+            else:
+                capacity_component = -0.2
+                notes.append("capacity=0")
+        elif self.availability_profile:
+            role_component = 0.0
+            capacity_component = -0.2
+            notes.append("role_not_in_capacity_profile")
+        else:
+            notes.append("availability_profile=empty")
+
+        if self.digest_mode == "high_precision":
+            score = confidence_component + role_component + capacity_component - 0.15
+            notes.append("mode=high_precision")
+        elif self.digest_mode == "high_recall":
+            score = confidence_component + role_component + capacity_component + 0.1
+            notes.append("mode=high_recall")
+        else:
+            score = confidence_component + role_component + capacity_component
+            notes.append("mode=balanced")
+
+        bounded_score = max(0.0, min(1.0, score))
+        return bounded_score, ", ".join(notes)
+
+
+def score_clusters(
+    session: Session, clusters: list[OpportunityCluster], settings: KOISSettings
+) -> dict[int, ClusterFilteringResult]:
+    policy = OpportunityFilterPolicy(settings)
+    results: dict[int, ClusterFilteringResult] = {}
+    unique_clusters = {cluster.id: cluster for cluster in clusters}.values()
+    for cluster in unique_clusters:
+        results[cluster.id] = policy.apply_to_cluster(cluster)
+    session.flush()
+    return results

--- a/job_scraper/kois/filtering.py
+++ b/job_scraper/kois/filtering.py
@@ -78,7 +78,7 @@ DEFAULT_ROLE_TAXONOMY: dict[str, list[str]] = {
 
 @dataclass(frozen=True)
 class ClusterFilteringResult:
-    role_category: str | None
+    role_category: str
     role_tags: list[str]
     relevance_score: float
     relevance_rationale: str
@@ -141,7 +141,7 @@ class OpportunityFilterPolicy:
         )
         return relevance >= threshold
 
-    def _classify_cluster(self, cluster: OpportunityCluster) -> tuple[str | None, list[str]]:
+    def _classify_cluster(self, cluster: OpportunityCluster) -> tuple[str, list[str]]:
         haystack_parts = [cluster.title, cluster.customer]
         for source in cluster.sources:
             record = source.record
@@ -156,7 +156,7 @@ class OpportunityFilterPolicy:
             )
         haystack = normalize_text(" ".join(part or "" for part in haystack_parts))
         if not haystack:
-            return None, []
+            return "generalist", []
 
         scores: dict[str, int] = {}
         for role, keywords in self.role_taxonomy.items():

--- a/job_scraper/kois/filtering.py
+++ b/job_scraper/kois/filtering.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import re
 
 from sqlalchemy.orm import Session
 
@@ -162,7 +163,7 @@ class OpportunityFilterPolicy:
             score = 0
             for keyword in keywords:
                 normalized = normalize_text(keyword)
-                if normalized and normalized in haystack:
+                if self._contains_keyword(haystack, normalized):
                     score += 1
             if score:
                 scores[role] = score
@@ -172,6 +173,13 @@ class OpportunityFilterPolicy:
         ranked = sorted(scores.items(), key=lambda item: (item[1], item[0]), reverse=True)
         role_tags = [role for role, _ in ranked[:3]]
         return ranked[0][0], role_tags
+
+    def _contains_keyword(self, haystack: str, keyword: str) -> bool:
+        if not keyword:
+            return False
+        escaped = re.escape(keyword).replace(r"\ ", r"\s+")
+        pattern = rf"(?<!\w){escaped}(?!\w)"
+        return re.search(pattern, haystack) is not None
 
     def _score_relevance(
         self, cluster: OpportunityCluster, role_category: str | None

--- a/job_scraper/kois/filtering.py
+++ b/job_scraper/kois/filtering.py
@@ -115,7 +115,11 @@ class OpportunityFilterPolicy:
         return result
 
     def should_include_digest(
-        self, cluster: OpportunityCluster, *, evaluated_relevance: float | None = None
+        self,
+        cluster: OpportunityCluster,
+        *,
+        evaluated_relevance: float | None = None,
+        min_relevance_override: float | None = None,
     ) -> bool:
         if cluster.review_status in (ReviewStatus.IGNORED, ReviewStatus.WATCH_ONLY):
             return False
@@ -129,7 +133,12 @@ class OpportunityFilterPolicy:
             if evaluated_relevance is not None
             else cluster.relevance_score
         )
-        return relevance >= self.min_relevance
+        threshold = (
+            min_relevance_override
+            if min_relevance_override is not None
+            else self.min_relevance
+        )
+        return relevance >= threshold
 
     def _classify_cluster(self, cluster: OpportunityCluster) -> tuple[str | None, list[str]]:
         haystack_parts = [cluster.title, cluster.customer]

--- a/job_scraper/kois/migrations.py
+++ b/job_scraper/kois/migrations.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable
 
+from sqlalchemy import inspect
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
 
@@ -9,6 +10,7 @@ from job_scraper.kois import schema  # noqa: F401
 INIT_MIGRATION_ID = "20260605_kois_phase1_init"
 DROP_CONTENT_HASH_UNIQUE_MIGRATION_ID = "20260606_drop_raw_source_content_hash_unique"
 PHASE2_INTELLIGENCE_MIGRATION_ID = "20260606_phase2_agreements_and_gaps"
+PHASE3_SALES_FILTERING_MIGRATION_ID = "20260607_phase3_sales_filtering"
 
 
 def _ensure_migrations_table(connection) -> None:
@@ -60,10 +62,58 @@ def _add_phase2_tables(connection) -> None:
     schema.AgreementGap.__table__.create(bind=connection, checkfirst=True)
 
 
+def _add_phase3_cluster_filtering_fields(connection) -> None:
+    inspector = inspect(connection)
+    columns = {column["name"] for column in inspector.get_columns("opportunity_clusters")}
+    if "role_category" not in columns:
+        connection.execute(
+            text("ALTER TABLE opportunity_clusters ADD COLUMN role_category VARCHAR(128)")
+        )
+    if "role_tags" not in columns:
+        connection.execute(
+            text("ALTER TABLE opportunity_clusters ADD COLUMN role_tags JSON")
+        )
+        connection.execute(
+            text(
+                "UPDATE opportunity_clusters SET role_tags = '[]' WHERE role_tags IS NULL"
+            )
+        )
+    if "relevance_score" not in columns:
+        connection.execute(
+            text(
+                "ALTER TABLE opportunity_clusters ADD COLUMN relevance_score FLOAT DEFAULT 0"
+            )
+        )
+        connection.execute(
+            text(
+                "UPDATE opportunity_clusters "
+                "SET relevance_score = 0 WHERE relevance_score IS NULL"
+            )
+        )
+    if "relevance_rationale" not in columns:
+        connection.execute(
+            text("ALTER TABLE opportunity_clusters ADD COLUMN relevance_rationale TEXT")
+        )
+
+    connection.execute(
+        text(
+            "CREATE INDEX IF NOT EXISTS ix_opportunity_clusters_role_category "
+            "ON opportunity_clusters (role_category)"
+        )
+    )
+    connection.execute(
+        text(
+            "CREATE INDEX IF NOT EXISTS ix_opportunity_clusters_relevance_score "
+            "ON opportunity_clusters (relevance_score)"
+        )
+    )
+
+
 MIGRATIONS: list[tuple[str, Callable]] = [
     (INIT_MIGRATION_ID, _run_init),
     (DROP_CONTENT_HASH_UNIQUE_MIGRATION_ID, _drop_content_hash_unique),
     (PHASE2_INTELLIGENCE_MIGRATION_ID, _add_phase2_tables),
+    (PHASE3_SALES_FILTERING_MIGRATION_ID, _add_phase3_cluster_filtering_fields),
 ]
 
 

--- a/job_scraper/kois/orchestrator.py
+++ b/job_scraper/kois/orchestrator.py
@@ -11,6 +11,7 @@ from job_scraper.kois.config import get_settings
 from job_scraper.kois.digest import send_digest_items
 from job_scraper.kois.domain import RawIngestionItem
 from job_scraper.kois.extraction import RecordExtractor
+from job_scraper.kois.filtering import OpportunityFilterPolicy, score_clusters
 from job_scraper.kois.gaps import discover_missing_agreement_gaps
 from job_scraper.kois.ingestion.imap_adapter import fetch_imap_items
 from job_scraper.kois.ingestion.procurement_adapter import fetch_procurement_items
@@ -92,6 +93,8 @@ def run_kois_pipeline(
     clusters = list(
         {cluster.id: cluster for cluster in [*touched_clusters, *pending_clusters]}.values()
     )
+    score_clusters(session, clusters, settings)
+    filter_policy = OpportunityFilterPolicy(settings)
     slack = SlackPoster(optional=True)
     digests = send_digest_items(
         session=session,
@@ -99,6 +102,8 @@ def run_kois_pipeline(
         slack=slack,
         live_posting=settings.run_live_slack,
         channel=settings.slack_channel,
+        settings=settings,
+        policy=filter_policy,
     )
     session.commit()
     return {

--- a/job_scraper/kois/review_api.py
+++ b/job_scraper/kois/review_api.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 from job_scraper.kois.analytics import phase2_summary
 from job_scraper.kois.config import get_settings
 from job_scraper.kois.db import get_db_session
-from job_scraper.kois.filtering import OpportunityFilterPolicy
+from job_scraper.kois.filtering import ClusterFilteringResult, OpportunityFilterPolicy
 from job_scraper.kois.gaps import discover_missing_agreement_gaps, set_gap_status
 from job_scraper.kois.repository import list_agreement_gaps, list_agreement_signals
 from job_scraper.kois.review import ReviewService
@@ -113,24 +113,26 @@ def relevant_opportunities(
     query = select(OpportunityCluster)
     if status:
         query = query.where(OpportunityCluster.review_status == status)
-    if role:
-        query = query.where(OpportunityCluster.role_category == role)
-    clusters = list(
-        session.execute(
-            query.order_by(
-                OpportunityCluster.relevance_score.desc(),
-                OpportunityCluster.confidence.desc(),
-                OpportunityCluster.id.desc(),
-            ).limit(limit)
-        ).scalars()
-    )
-    response = []
+    clusters = list(session.execute(query).scalars())
+    evaluated_matches: list[tuple[OpportunityCluster, ClusterFilteringResult]] = []
     for cluster in clusters:
         evaluation = policy.evaluate_cluster(cluster)
-        if evaluation.relevance_score < threshold or not policy.should_include_digest(
-            cluster, evaluated_relevance=evaluation.relevance_score
+        if role and evaluation.role_category != role:
+            continue
+        if not policy.should_include_digest(
+            cluster,
+            evaluated_relevance=evaluation.relevance_score,
+            min_relevance_override=threshold,
         ):
             continue
+        evaluated_matches.append((cluster, evaluation))
+
+    evaluated_matches.sort(
+        key=lambda item: (item[1].relevance_score, item[0].confidence, item[0].id),
+        reverse=True,
+    )
+    response = []
+    for cluster, evaluation in evaluated_matches[:limit]:
         response.append(
             {
                 "id": cluster.id,

--- a/job_scraper/kois/review_api.py
+++ b/job_scraper/kois/review_api.py
@@ -42,13 +42,11 @@ def list_clusters(
     q: str | None = None,
     session: Session = Depends(get_db_session),
 ):
+    settings = get_settings()
+    policy = OpportunityFilterPolicy(settings)
     query = select(OpportunityCluster)
     if status:
         query = query.where(OpportunityCluster.review_status == status)
-    if role:
-        query = query.where(OpportunityCluster.role_category == role)
-    if min_relevance_score is not None:
-        query = query.where(OpportunityCluster.relevance_score >= min_relevance_score)
     if q:
         query = query.where(
             or_(
@@ -58,22 +56,32 @@ def list_clusters(
             )
         )
     clusters = list(session.execute(query).scalars())
-    return [
-        {
-            "id": cluster.id,
-            "cluster_key": cluster.cluster_key,
-            "title": cluster.title,
-            "customer": cluster.customer,
-            "review_status": cluster.review_status.value,
-            "confidence": cluster.confidence,
-            "source_count": len(cluster.sources),
-            "role_category": cluster.role_category,
-            "role_tags": cluster.role_tags_json,
-            "relevance_score": cluster.relevance_score,
-            "relevance_rationale": cluster.relevance_rationale,
-        }
-        for cluster in clusters
-    ]
+    response = []
+    for cluster in clusters:
+        evaluation = policy.evaluate_cluster(cluster)
+        if role and evaluation.role_category != role:
+            continue
+        if (
+            min_relevance_score is not None
+            and evaluation.relevance_score < min_relevance_score
+        ):
+            continue
+        response.append(
+            {
+                "id": cluster.id,
+                "cluster_key": cluster.cluster_key,
+                "title": cluster.title,
+                "customer": cluster.customer,
+                "review_status": cluster.review_status.value,
+                "confidence": cluster.confidence,
+                "source_count": len(cluster.sources),
+                "role_category": evaluation.role_category,
+                "role_tags": evaluation.role_tags,
+                "relevance_score": evaluation.relevance_score,
+                "relevance_rationale": evaluation.relevance_rationale,
+            }
+        )
+    return response
 
 
 @app.get("/review-queue")

--- a/job_scraper/kois/review_api.py
+++ b/job_scraper/kois/review_api.py
@@ -6,13 +6,15 @@ from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
 
 from job_scraper.kois.analytics import phase2_summary
+from job_scraper.kois.config import get_settings
 from job_scraper.kois.db import get_db_session
+from job_scraper.kois.filtering import OpportunityFilterPolicy
 from job_scraper.kois.gaps import discover_missing_agreement_gaps, set_gap_status
 from job_scraper.kois.repository import list_agreement_gaps, list_agreement_signals
 from job_scraper.kois.review import ReviewService
 from job_scraper.kois.schema import GapStatus, OpportunityCluster, ReviewStatus
 
-app = FastAPI(title="KOIS Phase 2 Review And Intelligence API")
+app = FastAPI(title="KOIS Review, Intelligence, And Filtering API")
 
 
 class ReviewUpdate(BaseModel):
@@ -35,12 +37,18 @@ def healthcheck():
 @app.get("/clusters")
 def list_clusters(
     status: ReviewStatus | None = None,
+    role: str | None = None,
+    min_relevance_score: float | None = None,
     q: str | None = None,
     session: Session = Depends(get_db_session),
 ):
     query = select(OpportunityCluster)
     if status:
         query = query.where(OpportunityCluster.review_status == status)
+    if role:
+        query = query.where(OpportunityCluster.role_category == role)
+    if min_relevance_score is not None:
+        query = query.where(OpportunityCluster.relevance_score >= min_relevance_score)
     if q:
         query = query.where(
             or_(
@@ -59,6 +67,10 @@ def list_clusters(
             "review_status": cluster.review_status.value,
             "confidence": cluster.confidence,
             "source_count": len(cluster.sources),
+            "role_category": cluster.role_category,
+            "role_tags": cluster.role_tags_json,
+            "relevance_score": cluster.relevance_score,
+            "relevance_rationale": cluster.relevance_rationale,
         }
         for cluster in clusters
     ]
@@ -81,6 +93,60 @@ def review_queue(session: Session = Depends(get_db_session)):
         }
         for cluster in clusters
     ]
+
+
+@app.get("/opportunities/relevant")
+def relevant_opportunities(
+    status: ReviewStatus | None = None,
+    role: str | None = None,
+    min_relevance_score: float | None = None,
+    limit: int = 100,
+    session: Session = Depends(get_db_session),
+):
+    settings = get_settings()
+    policy = OpportunityFilterPolicy(settings)
+    threshold = (
+        min_relevance_score
+        if min_relevance_score is not None
+        else settings.digest_min_relevance_score
+    )
+    query = select(OpportunityCluster)
+    if status:
+        query = query.where(OpportunityCluster.review_status == status)
+    if role:
+        query = query.where(OpportunityCluster.role_category == role)
+    clusters = list(
+        session.execute(
+            query.order_by(
+                OpportunityCluster.relevance_score.desc(),
+                OpportunityCluster.confidence.desc(),
+                OpportunityCluster.id.desc(),
+            ).limit(limit)
+        ).scalars()
+    )
+    response = []
+    for cluster in clusters:
+        evaluation = policy.evaluate_cluster(cluster)
+        if evaluation.relevance_score < threshold or not policy.should_include_digest(
+            cluster, evaluated_relevance=evaluation.relevance_score
+        ):
+            continue
+        response.append(
+            {
+                "id": cluster.id,
+                "cluster_key": cluster.cluster_key,
+                "title": cluster.title,
+                "customer": cluster.customer,
+                "review_status": cluster.review_status.value,
+                "confidence": cluster.confidence,
+                "source_count": len(cluster.sources),
+                "role_category": evaluation.role_category,
+                "role_tags": evaluation.role_tags,
+                "relevance_score": evaluation.relevance_score,
+                "relevance_rationale": evaluation.relevance_rationale,
+            }
+        )
+    return response
 
 
 @app.patch("/clusters/{cluster_id}/status")

--- a/job_scraper/kois/schema.py
+++ b/job_scraper/kois/schema.py
@@ -95,6 +95,12 @@ class OpportunityCluster(Base):
         Enum(ReviewStatus), default=ReviewStatus.NEEDS_REVIEW, index=True
     )
     confidence: Mapped[float] = mapped_column(default=0.0)
+    role_category: Mapped[Optional[str]] = mapped_column(
+        String(128), nullable=True, index=True
+    )
+    role_tags_json: Mapped[list] = mapped_column("role_tags", JSON, default=list)
+    relevance_score: Mapped[float] = mapped_column(default=0.0, index=True)
+    relevance_rationale: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=datetime.utcnow
     )

--- a/job_scraper/slack_poster.py
+++ b/job_scraper/slack_poster.py
@@ -81,6 +81,8 @@ class SlackPoster:
         confidence = payload.get("confidence", 0)
         review_status = payload.get("review_status", "needs_review")
         cluster_id = payload.get("cluster_id")
+        role_category = payload.get("role_category") or "generalist"
+        relevance_score = payload.get("relevance_score", 0)
         text = f"KOIS digest: {title}"
         blocks = [
             HeaderBlock(text=PlainTextObject(text=f"KOIS: {title}")),
@@ -91,6 +93,8 @@ class SlackPoster:
                     MarkdownTextObject(text=f"*Kilder:*\n{source_count}"),
                     MarkdownTextObject(text=f"*Status:*\n{review_status}"),
                     MarkdownTextObject(text=f"*Confidence:*\n{confidence:.2f}"),
+                    MarkdownTextObject(text=f"*Role:*\n{role_category}"),
+                    MarkdownTextObject(text=f"*Relevance:*\n{relevance_score:.2f}"),
                     MarkdownTextObject(text=f"*Cluster ID:*\n{cluster_id}"),
                 ]
             ),

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -265,3 +265,96 @@ def test_digest_cadence_leaves_unsent_for_later_delivery():
     assert sent == []
     assert len(cluster.digest_items) == 1
     assert cluster.digest_items[0].sent_at is None
+
+
+def test_digest_cadence_ignores_unsent_rows_for_latest_sent_lookup(monkeypatch):
+    session = _session()
+    raw = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="scraper",
+            source_name="mercell",
+            external_id="id-cadence-null-order",
+            raw_body="raw-data",
+        ),
+    )
+    record = create_extracted_record(
+        session,
+        {
+            "raw_source_item_id": raw.id,
+            "title": "Assignment",
+            "customer": "Kynd",
+            "broker": "mercell",
+            "source_url": "https://example.com/cadence-null-order",
+            "deadline": "2026-06-30",
+            "description": "desc",
+            "summary": "sum",
+            "extracted_data": {},
+            "extraction_confidence": 0.95,
+        },
+    )
+    sent_cluster = create_or_update_cluster(
+        session=session,
+        cluster_key="https://example.com/sent",
+        title="Sent",
+        customer="Kynd",
+        confidence=0.95,
+        review_status=ReviewStatus.AUTO_ACCEPTED,
+    )
+    sent_item = create_digest_item(
+        session=session,
+        cluster=sent_cluster,
+        status=ReviewStatus.AUTO_ACCEPTED,
+        payload={"cluster_id": sent_cluster.id},
+    )
+    mark_digest_sent(session, sent_item, slack_ts="123.45")
+
+    unsent_cluster = create_or_update_cluster(
+        session=session,
+        cluster_key="https://example.com/unsent",
+        title="Unsent",
+        customer="Kynd",
+        confidence=0.95,
+        review_status=ReviewStatus.AUTO_ACCEPTED,
+    )
+    create_digest_item(
+        session=session,
+        cluster=unsent_cluster,
+        status=ReviewStatus.AUTO_ACCEPTED,
+        payload={"cluster_id": unsent_cluster.id},
+    )
+
+    candidate_cluster = create_or_update_cluster(
+        session=session,
+        cluster_key="https://example.com/candidate",
+        title="Candidate",
+        customer="Kynd",
+        confidence=0.95,
+        review_status=ReviewStatus.AUTO_ACCEPTED,
+    )
+    attach_cluster_source(session, candidate_cluster, record, 0.95, "url")
+    candidate_cluster.primary_source_record_id = record.id
+    candidate_cluster.relevance_score = 0.9
+    session.commit()
+
+    original_execute = session.execute
+
+    def _execute_with_postgres_nulls_first(statement, *args, **kwargs):
+        if "SELECT digest_items.sent_at" in str(statement):
+            assert "sent_at IS NOT NULL" in str(statement)
+        return original_execute(statement, *args, **kwargs)
+
+    monkeypatch.setattr(session, "execute", _execute_with_postgres_nulls_first)
+
+    sent = send_digest_items(
+        session=session,
+        clusters=[candidate_cluster],
+        slack=SlackPoster(optional=True),
+        live_posting=False,
+        channel="job-posting",
+        settings=KOISSettings(digest_cadence_minutes=120),
+    )
+    session.commit()
+
+    assert sent == []
+    assert candidate_cluster.digest_items[0].sent_at is None

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -1,11 +1,14 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
+from job_scraper.kois.config import KOISSettings
 from job_scraper.kois.digest import send_digest_items
 from job_scraper.kois.repository import (
     attach_cluster_source,
+    create_digest_item,
     create_extracted_record,
     create_or_update_cluster,
+    mark_digest_sent,
     upsert_raw_source_item,
 )
 from job_scraper.kois.schema import Base, ReviewStatus
@@ -131,4 +134,134 @@ def test_digest_not_marked_sent_when_live_post_fails():
     session.commit()
 
     assert sent == []
+    assert cluster.digest_items[0].sent_at is None
+
+
+def test_digest_drops_unsent_items_when_relevance_falls_below_threshold():
+    session = _session()
+    raw = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="scraper",
+            source_name="mercell",
+            external_id="id-relevance",
+            raw_body="raw-data",
+        ),
+    )
+    record = create_extracted_record(
+        session,
+        {
+            "raw_source_item_id": raw.id,
+            "title": "Assignment",
+            "customer": "Kynd",
+            "broker": "mercell",
+            "source_url": "https://example.com/relevance",
+            "deadline": "2026-06-30",
+            "description": "desc",
+            "summary": "sum",
+            "extracted_data": {},
+            "extraction_confidence": 0.95,
+        },
+    )
+    cluster = create_or_update_cluster(
+        session=session,
+        cluster_key="https://example.com/relevance",
+        title="Assignment",
+        customer="Kynd",
+        confidence=0.95,
+        review_status=ReviewStatus.AUTO_ACCEPTED,
+    )
+    attach_cluster_source(session, cluster, record, 0.95, "url")
+    cluster.primary_source_record_id = record.id
+    cluster.relevance_score = 0.2
+    create_digest_item(
+        session=session,
+        cluster=cluster,
+        status=cluster.review_status,
+        payload={"cluster_id": cluster.id},
+    )
+    session.commit()
+
+    sent = send_digest_items(
+        session=session,
+        clusters=[cluster],
+        slack=SlackPoster(optional=True),
+        live_posting=False,
+        channel="job-posting",
+        settings=KOISSettings(digest_min_relevance_score=0.8),
+    )
+    session.commit()
+
+    assert sent == []
+    assert len(cluster.digest_items) == 0
+
+
+def test_digest_cadence_leaves_unsent_for_later_delivery():
+    session = _session()
+    raw = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="scraper",
+            source_name="mercell",
+            external_id="id-cadence",
+            raw_body="raw-data",
+        ),
+    )
+    record = create_extracted_record(
+        session,
+        {
+            "raw_source_item_id": raw.id,
+            "title": "Assignment",
+            "customer": "Kynd",
+            "broker": "mercell",
+            "source_url": "https://example.com/cadence",
+            "deadline": "2026-06-30",
+            "description": "desc",
+            "summary": "sum",
+            "extracted_data": {},
+            "extraction_confidence": 0.95,
+        },
+    )
+    previous_cluster = create_or_update_cluster(
+        session=session,
+        cluster_key="https://example.com/previous",
+        title="Previous",
+        customer="Kynd",
+        confidence=0.95,
+        review_status=ReviewStatus.AUTO_ACCEPTED,
+    )
+    previous = create_digest_item(
+        session=session,
+        cluster=previous_cluster,
+        status=ReviewStatus.AUTO_ACCEPTED,
+        payload={"cluster_id": previous_cluster.id},
+    )
+    mark_digest_sent(session, previous, slack_ts="123.45")
+    session.flush()
+
+    cluster = create_or_update_cluster(
+        session=session,
+        cluster_key="https://example.com/cadence",
+        title="Assignment",
+        customer="Kynd",
+        confidence=0.95,
+        review_status=ReviewStatus.AUTO_ACCEPTED,
+    )
+    attach_cluster_source(session, cluster, record, 0.95, "url")
+    cluster.primary_source_record_id = record.id
+    cluster.relevance_score = 0.9
+    session.commit()
+
+    sent = send_digest_items(
+        session=session,
+        clusters=[cluster],
+        slack=SlackPoster(optional=True),
+        live_posting=False,
+        channel="job-posting",
+        settings=KOISSettings(digest_cadence_minutes=120),
+    )
+    session.commit()
+
+    assert sent == []
+    assert len(cluster.digest_items) == 1
     assert cluster.digest_items[0].sent_at is None

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -60,12 +60,16 @@ def test_digest_item_not_resent_when_already_sent():
     cluster.primary_source_record_id = record.id
     session.commit()
 
-    slack = SlackPoster(optional=True)
+    class SuccessfulSlack(SlackPoster):
+        def post_digest(self, payload, channel="job-posting"):
+            return {"ts": "123.45"}
+
+    slack = SuccessfulSlack(optional=True)
     first = send_digest_items(
         session=session,
         clusters=[cluster],
         slack=slack,
-        live_posting=False,
+        live_posting=True,
         channel="job-posting",
     )
     session.commit()
@@ -73,7 +77,7 @@ def test_digest_item_not_resent_when_already_sent():
         session=session,
         clusters=[cluster],
         slack=slack,
-        live_posting=False,
+        live_posting=True,
         channel="job-posting",
     )
     session.commit()
@@ -358,3 +362,73 @@ def test_digest_cadence_ignores_unsent_rows_for_latest_sent_lookup(monkeypatch):
 
     assert sent == []
     assert candidate_cluster.digest_items[0].sent_at is None
+
+
+def test_dry_run_does_not_block_later_live_send_with_cadence():
+    session = _session()
+    raw = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="scraper",
+            source_name="mercell",
+            external_id="id-dry-run-cadence",
+            raw_body="raw-data",
+        ),
+    )
+    record = create_extracted_record(
+        session,
+        {
+            "raw_source_item_id": raw.id,
+            "title": "Assignment",
+            "customer": "Kynd",
+            "broker": "mercell",
+            "source_url": "https://example.com/dry-run-cadence",
+            "deadline": "2026-06-30",
+            "description": "desc",
+            "summary": "sum",
+            "extracted_data": {},
+            "extraction_confidence": 0.95,
+        },
+    )
+    cluster = create_or_update_cluster(
+        session=session,
+        cluster_key="https://example.com/dry-run-cadence",
+        title="Assignment",
+        customer="Kynd",
+        confidence=0.95,
+        review_status=ReviewStatus.AUTO_ACCEPTED,
+    )
+    attach_cluster_source(session, cluster, record, 0.95, "url")
+    cluster.primary_source_record_id = record.id
+    cluster.relevance_score = 0.9
+    session.commit()
+
+    dry_run = send_digest_items(
+        session=session,
+        clusters=[cluster],
+        slack=SlackPoster(optional=True),
+        live_posting=False,
+        channel="job-posting",
+        settings=KOISSettings(digest_cadence_minutes=120),
+    )
+    session.commit()
+
+    assert len(dry_run) == 1
+    assert cluster.digest_items[0].sent_at is None
+
+    class SuccessfulSlack(SlackPoster):
+        def post_digest(self, payload, channel="job-posting"):
+            return {"ts": "456.78"}
+
+    live_run = send_digest_items(
+        session=session,
+        clusters=[cluster],
+        slack=SuccessfulSlack(optional=True),
+        live_posting=True,
+        channel="job-posting",
+        settings=KOISSettings(digest_cadence_minutes=120),
+    )
+    session.commit()
+
+    assert len(live_run) == 1
+    assert cluster.digest_items[0].sent_at is not None

--- a/tests/test_phase3_filtering.py
+++ b/tests/test_phase3_filtering.py
@@ -16,11 +16,18 @@ def _session() -> Session:
     return Session(bind=engine, future=True)
 
 
-def _make_cluster(session: Session, *, title: str, confidence: float = 0.95):
-    if "project manager" in title.lower():
-        description = "Need a senior project manager to lead delivery and stakeholder coordination."
-    else:
-        description = "Need strong data engineer with dbt and airflow."
+def _make_cluster(
+    session: Session,
+    *,
+    title: str,
+    confidence: float = 0.95,
+    description: str | None = None,
+):
+    if description is None:
+        if "project manager" in title.lower():
+            description = "Need a senior project manager to lead delivery and stakeholder coordination."
+        else:
+            description = "Need strong data engineer with dbt and airflow."
     raw = upsert_raw_source_item(
         session,
         RawIngestionItem(
@@ -176,6 +183,22 @@ def test_relevant_opportunities_limit_applies_after_fresh_relevance_sort(monkeyp
 
     assert len(response) == 1
     assert response[0]["id"] == fresh_high.id
+
+
+def test_role_classification_uses_word_boundaries_for_keywords():
+    session = _session()
+    cluster = _make_cluster(
+        session,
+        title="Frontend JavaScript Developer",
+        description="Need a frontend specialist with javascript and react experience.",
+    )
+    settings = KOISSettings()
+    policy = OpportunityFilterPolicy(settings)
+
+    result = policy.evaluate_cluster(cluster)
+
+    assert result.role_category == "frontend"
+    assert "backend" not in result.role_tags
 
 
 def test_invalid_availability_profile_json_raises():

--- a/tests/test_phase3_filtering.py
+++ b/tests/test_phase3_filtering.py
@@ -1,0 +1,124 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from job_scraper.kois import review_api
+from job_scraper.kois.config import KOISSettings
+from job_scraper.kois.filtering import OpportunityFilterPolicy, score_clusters
+from job_scraper.kois.repository import attach_cluster_source, create_extracted_record, create_or_update_cluster, upsert_raw_source_item
+from job_scraper.kois.schema import Base, ReviewStatus
+from job_scraper.kois.domain import RawIngestionItem
+
+
+def _session() -> Session:
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    return Session(bind=engine, future=True)
+
+
+def _make_cluster(session: Session, *, title: str, confidence: float = 0.95):
+    if "project manager" in title.lower():
+        description = "Need a senior project manager to lead delivery and stakeholder coordination."
+    else:
+        description = "Need strong data engineer with dbt and airflow."
+    raw = upsert_raw_source_item(
+        session,
+        RawIngestionItem(
+            source_type="scraper",
+            source_name="mercell",
+            external_id=f"id-{title}",
+            raw_body="raw-data",
+        ),
+    )
+    record = create_extracted_record(
+        session,
+        {
+            "raw_source_item_id": raw.id,
+            "title": title,
+            "customer": "Kynd",
+            "broker": "mercell",
+            "source_url": f"https://example.com/{raw.id}",
+            "deadline": "2026-06-30",
+            "description": description,
+            "summary": None,
+            "extracted_data": {},
+            "extraction_confidence": 0.95,
+        },
+    )
+    cluster = create_or_update_cluster(
+        session=session,
+        cluster_key=f"https://example.com/{raw.id}",
+        title=title,
+        customer="Kynd",
+        confidence=confidence,
+        review_status=ReviewStatus.AUTO_ACCEPTED,
+    )
+    attach_cluster_source(session, cluster, record, 0.95, "url")
+    cluster.primary_source_record_id = record.id
+    session.flush()
+    return cluster
+
+
+def test_phase3_policy_classifies_and_scores():
+    session = _session()
+    cluster = _make_cluster(session, title="Senior Data Engineer")
+    settings = KOISSettings(availability_profile_json='{"data_engineering": 2}')
+    policy = OpportunityFilterPolicy(settings)
+    result = policy.apply_to_cluster(cluster)
+    session.commit()
+
+    assert result.role_category == "data_engineering"
+    assert cluster.relevance_score > 0.5
+    assert policy.should_include_digest(cluster)
+
+
+def test_phase3_policy_blocks_low_confidence_needs_review():
+    session = _session()
+    cluster = _make_cluster(session, title="Senior Data Engineer", confidence=0.6)
+    cluster.review_status = ReviewStatus.NEEDS_REVIEW
+    settings = KOISSettings(
+        availability_profile_json='{"data_engineering": 3}',
+        digest_min_source_confidence=0.75,
+    )
+    policy = OpportunityFilterPolicy(settings)
+    policy.apply_to_cluster(cluster)
+
+    assert policy.should_include_digest(cluster) is False
+
+
+def test_score_clusters_persists_phase3_fields():
+    session = _session()
+    cluster = _make_cluster(session, title="Backend Developer")
+    settings = KOISSettings(availability_profile_json='{"backend": 1}')
+    score_clusters(session, [cluster], settings)
+    session.commit()
+
+    assert cluster.role_category is not None
+    assert isinstance(cluster.role_tags_json, list)
+    assert cluster.relevance_rationale is not None
+
+
+def test_relevant_opportunities_endpoint_uses_shared_policy(monkeypatch):
+    session = _session()
+    relevant_cluster = _make_cluster(session, title="Senior Data Engineer")
+    irrelevant_cluster = _make_cluster(session, title="Project Manager")
+    irrelevant_cluster.relevance_score = 0.0
+    session.commit()
+
+    settings = KOISSettings(
+        availability_profile_json='{"data_engineering": 2}',
+        digest_min_relevance_score=0.45,
+    )
+    monkeypatch.setattr(review_api, "get_settings", lambda: settings)
+
+    response = review_api.relevant_opportunities(session=session, limit=50)
+    returned_ids = {item["id"] for item in response}
+
+    assert relevant_cluster.id in returned_ids
+    assert irrelevant_cluster.id not in returned_ids
+
+
+def test_invalid_availability_profile_json_raises():
+    settings = KOISSettings(availability_profile_json="not-json")
+    with pytest.raises(ValueError):
+        _ = settings.availability_profile

--- a/tests/test_phase3_filtering.py
+++ b/tests/test_phase3_filtering.py
@@ -201,6 +201,49 @@ def test_role_classification_uses_word_boundaries_for_keywords():
     assert "backend" not in result.role_tags
 
 
+def test_sparse_cluster_classifies_as_generalist():
+    session = _session()
+    cluster = create_or_update_cluster(
+        session=session,
+        cluster_key="https://example.com/sparse",
+        title=None,
+        customer=None,
+        confidence=0.95,
+        review_status=ReviewStatus.AUTO_ACCEPTED,
+    )
+    settings = KOISSettings()
+    policy = OpportunityFilterPolicy(settings)
+
+    result = policy.evaluate_cluster(cluster)
+
+    assert result.role_category == "generalist"
+    assert result.role_tags == []
+
+
+def test_relevant_opportunities_role_generalist_includes_sparse_cluster(monkeypatch):
+    session = _session()
+    cluster = create_or_update_cluster(
+        session=session,
+        cluster_key="https://example.com/sparse-generalist",
+        title=None,
+        customer=None,
+        confidence=0.95,
+        review_status=ReviewStatus.AUTO_ACCEPTED,
+    )
+    session.commit()
+
+    settings = KOISSettings(digest_min_relevance_score=0.1)
+    monkeypatch.setattr(review_api, "get_settings", lambda: settings)
+
+    response = review_api.relevant_opportunities(
+        session=session, role="generalist", limit=10
+    )
+    returned_ids = {item["id"] for item in response}
+
+    assert cluster.id in returned_ids
+    assert response[0]["role_category"] == "generalist"
+
+
 def test_invalid_availability_profile_json_raises():
     settings = KOISSettings(availability_profile_json="not-json")
     with pytest.raises(ValueError):

--- a/tests/test_phase3_filtering.py
+++ b/tests/test_phase3_filtering.py
@@ -205,3 +205,11 @@ def test_invalid_availability_profile_json_raises():
     settings = KOISSettings(availability_profile_json="not-json")
     with pytest.raises(ValueError):
         _ = settings.availability_profile
+
+
+def test_availability_profile_rejects_boolean_capacity_values():
+    settings = KOISSettings(availability_profile_json='{"data_engineering": true}')
+    with pytest.raises(
+        ValueError, match="must be an integer capacity value"
+    ):
+        _ = settings.availability_profile

--- a/tests/test_phase3_filtering.py
+++ b/tests/test_phase3_filtering.py
@@ -213,3 +213,28 @@ def test_availability_profile_rejects_boolean_capacity_values():
         ValueError, match="must be an integer capacity value"
     ):
         _ = settings.availability_profile
+
+
+def test_list_clusters_filters_role_and_relevance_on_fresh_evaluation(monkeypatch):
+    session = _session()
+    cluster = _make_cluster(session, title="Senior Data Engineer")
+    cluster.role_category = "backend"
+    cluster.relevance_score = 0.0
+    session.commit()
+
+    settings = KOISSettings(
+        availability_profile_json='{"data_engineering": 2}',
+        digest_min_relevance_score=0.45,
+    )
+    monkeypatch.setattr(review_api, "get_settings", lambda: settings)
+
+    response = review_api.list_clusters(
+        session=session,
+        role="data_engineering",
+        min_relevance_score=0.5,
+    )
+
+    assert len(response) == 1
+    assert response[0]["id"] == cluster.id
+    assert response[0]["role_category"] == "data_engineering"
+    assert response[0]["relevance_score"] >= 0.5

--- a/tests/test_phase3_filtering.py
+++ b/tests/test_phase3_filtering.py
@@ -118,6 +118,66 @@ def test_relevant_opportunities_endpoint_uses_shared_policy(monkeypatch):
     assert irrelevant_cluster.id not in returned_ids
 
 
+def test_relevant_opportunities_filters_role_on_fresh_evaluation(monkeypatch):
+    session = _session()
+    cluster = _make_cluster(session, title="Senior Data Engineer")
+    cluster.role_category = "backend"
+    session.commit()
+
+    settings = KOISSettings(
+        availability_profile_json='{"data_engineering": 2}',
+        digest_min_relevance_score=0.45,
+    )
+    monkeypatch.setattr(review_api, "get_settings", lambda: settings)
+
+    response = review_api.relevant_opportunities(
+        session=session, role="data_engineering", limit=10
+    )
+
+    assert len(response) == 1
+    assert response[0]["id"] == cluster.id
+    assert response[0]["role_category"] == "data_engineering"
+
+
+def test_relevant_opportunities_honors_query_min_relevance_override(monkeypatch):
+    session = _session()
+    cluster = _make_cluster(session, title="Senior Data Engineer")
+    session.commit()
+
+    settings = KOISSettings(
+        availability_profile_json='{"data_engineering": 1}',
+        digest_min_relevance_score=0.9,
+    )
+    monkeypatch.setattr(review_api, "get_settings", lambda: settings)
+
+    response = review_api.relevant_opportunities(
+        session=session, min_relevance_score=0.5, limit=10
+    )
+    returned_ids = {item["id"] for item in response}
+
+    assert cluster.id in returned_ids
+
+
+def test_relevant_opportunities_limit_applies_after_fresh_relevance_sort(monkeypatch):
+    session = _session()
+    stale_high = _make_cluster(session, title="Project Manager")
+    fresh_high = _make_cluster(session, title="Senior Data Engineer")
+    stale_high.relevance_score = 0.99
+    fresh_high.relevance_score = 0.01
+    session.commit()
+
+    settings = KOISSettings(
+        availability_profile_json='{"data_engineering": 2}',
+        digest_min_relevance_score=0.45,
+    )
+    monkeypatch.setattr(review_api, "get_settings", lambda: settings)
+
+    response = review_api.relevant_opportunities(session=session, limit=1)
+
+    assert len(response) == 1
+    assert response[0]["id"] == fresh_high.id
+
+
 def test_invalid_availability_profile_json_raises():
     settings = KOISSettings(availability_profile_json="not-json")
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- implement KOIS Phase 3 filtering core: role classification, availability-aware relevance scoring, cluster persistence fields, migration, and shared filtering policy wiring across orchestrator + digest + API
- add filtering delivery surfaces: configurable digest thresholds/cadence, enriched Slack digest payloads, and a new `GET /opportunities/relevant` endpoint aligned with the same policy
- add regression coverage for phase 3 behavior and digest idempotency edge cases, and update `README.md` + `PID.md` to reflect the new phase status and configuration surface

## Test plan
- [x] `PYTHONPATH=. .venv/bin/ruff check .`
- [x] `PYTHONPATH=. .venv/bin/pytest`
- [x] Verified all tests pass (46 passed)
- [x] Manually reviewed archive-preservation invariant: filtering only affects presentation (`digest`/`review_api`) and does not alter ingestion/clustering evidence retention

## Notes
- KOIS planning canvas was updated at `/Users/holene/.cursor/projects/Users-holene-repos-kynd-job-scraper/canvases/kois-planning.canvas.tsx` to keep roadmap metadata aligned with Phase 3 execution.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what gets posted to Slack and which clusters surface in API/digest paths; mis-tuned thresholds or cadence could hide opportunities, but ingestion and stored evidence are untouched.
> 
> **Overview**
> Adds **KOIS Phase 3 sales filtering**: deterministic role classification and availability-aware relevance scoring, persisted on `opportunity_clusters` via a new migration and wired through the pipeline before digest/API output.
> 
> Introduces shared `OpportunityFilterPolicy` (configurable `DIGEST_MODE`, relevance/confidence thresholds, optional `AVAILABILITY_PROFILE_JSON` / `ROLE_TAXONOMY_JSON`) so **Slack digests**, **`GET /opportunities/relevant`**, and **`GET /clusters`** use the same inclusion rules. Digests gain cadence gating (`DIGEST_CADENCE_MINUTES`), relevance-based cleanup of unsent items, dry-run payloads without marking sent, and Slack fields for role/relevance.
> 
> Docs/README/PID updated for Phases 1–3; regression tests cover policy, API filtering, and digest idempotency/cadence edge cases. Filtering is explicitly **presentation-only**—ingestion and archive retention are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1e8e4aa73b02d9bb6cf5abf7aecfd69056613f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->